### PR TITLE
Add idempotency-spring module (OncePerRequestFilter + @Idempotent)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,5 +240,3 @@ This includes the explanations and the current implementation status.
 ### Not started — do not implement
 - providers/idempotency-redis
 - idempotency-spring-boot-starter
-
-claude --resume c1966137-a8ce-4a03-9a80-f251bf9953fe 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,8 +235,10 @@ This includes the explanations and the current implementation status.
 - providers/idempotency-inmemory (InMemoryIdempotencyStore)
 - providers/idempotency-jdbc (JdbcIdempotencyStore with Testcontainers MySQL tests)
 - idempotency-test (IdempotencyStoreContract)
+- idempotency-spring (IdempotencyFilter + @Idempotent annotation)
 
 ### Not started — do not implement
 - providers/idempotency-redis
-- idempotency-spring
 - idempotency-spring-boot-starter
+
+claude --resume c1966137-a8ce-4a03-9a80-f251bf9953fe 

--- a/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyConfig.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyConfig.java
@@ -23,11 +23,13 @@ public final class IdempotencyConfig {
     private final Duration defaultTtl;
     private final Duration defaultLockTimeout;
     private final boolean keyRequired;
+    private final String keyHeader;
 
     private IdempotencyConfig(Builder builder) {
         this.defaultTtl = builder.defaultTtl;
         this.defaultLockTimeout = builder.defaultLockTimeout;
         this.keyRequired = builder.keyRequired;
+        this.keyHeader = builder.keyHeader;
     }
 
     public static Builder builder() {
@@ -50,10 +52,15 @@ public final class IdempotencyConfig {
         return keyRequired;
     }
 
+    public String keyHeader() {
+        return keyHeader;
+    }
+
     public static final class Builder {
         private Duration defaultTtl = Duration.ofHours(24);
         private Duration defaultLockTimeout = Duration.ofSeconds(10);
         private boolean keyRequired = true;
+        private String keyHeader = "Idempotency-Key";
 
         public Builder defaultTtl(Duration ttl) {
             Objects.requireNonNull(ttl, "defaultTtl must not be null");
@@ -72,6 +79,11 @@ public final class IdempotencyConfig {
             return this;
         }
 
+        public Builder keyHeader(String keyHeader) {
+            this.keyHeader = keyHeader;
+            return this;
+        }
+
         public IdempotencyConfig build() {
             if (defaultTtl.isZero() || defaultTtl.isNegative()) {
                 throw new IllegalArgumentException("defaultTtl must be positive, got: " + defaultTtl);
@@ -80,6 +92,9 @@ public final class IdempotencyConfig {
                 throw new IllegalArgumentException(
                         "defaultLockTimeout must be at least 2ms (engine divides by 2 for heartbeat interval), got: "
                                 + defaultLockTimeout);
+            }
+            if (keyHeader == null || keyHeader.isBlank()) {
+                throw new IllegalArgumentException("keyHeader must not be blank");
             }
             return new IdempotencyConfig(this);
         }

--- a/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyConfigTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyConfigTest.java
@@ -1,0 +1,28 @@
+package io.github.josipmusa.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class IdempotencyConfigTest {
+
+    @Test
+    void defaults_keyHeaderIsIdempotencyKey() {
+        assertThat(IdempotencyConfig.defaults().keyHeader()).isEqualTo("Idempotency-Key");
+    }
+
+    @Test
+    void builder_customKeyHeader() {
+        IdempotencyConfig config =
+                IdempotencyConfig.builder().keyHeader("X-Request-Id").build();
+        assertThat(config.keyHeader()).isEqualTo("X-Request-Id");
+    }
+
+    @Test
+    void builder_blankKeyHeader_throws() {
+        assertThatThrownBy(() -> IdempotencyConfig.builder().keyHeader("  ").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("keyHeader must not be blank");
+    }
+}

--- a/idempotency-spring/pom.xml
+++ b/idempotency-spring/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.josipmusa</groupId>
+        <artifactId>idempotency4j</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>idempotency-spring</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.josipmusa</groupId>
+            <artifactId>idempotency-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/idempotency-spring/pom.xml
+++ b/idempotency-spring/pom.xml
@@ -27,6 +27,12 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
+++ b/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
@@ -1,0 +1,142 @@
+package io.github.josipmusa.idempotency.spring;
+
+import io.github.josipmusa.core.ExecutionResult;
+import io.github.josipmusa.core.IdempotencyConfig;
+import io.github.josipmusa.core.IdempotencyContext;
+import io.github.josipmusa.core.IdempotencyEngine;
+import io.github.josipmusa.core.IdempotencyStore;
+import io.github.josipmusa.core.StoredResponse;
+import io.github.josipmusa.core.exception.IdempotencyLockTimeoutException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+/**
+ * Spring MVC filter that enforces idempotency for handler methods annotated with {@link Idempotent}.
+ *
+ * <p>Uses {@link RequestMappingHandlerMapping} to resolve the handler for each request, then checks
+ * for the {@link Idempotent} annotation. If present, it delegates to {@link IdempotencyEngine} and
+ * either stores the new response or replays the stored one for duplicates.
+ *
+ * <p>Do not annotate with {@code @Component} or {@code @Bean} — wiring belongs in the starter.
+ */
+public class IdempotencyFilter extends OncePerRequestFilter {
+
+    private final IdempotencyEngine engine;
+    private final IdempotencyStore store;
+    private final IdempotencyConfig config;
+    private final RequestMappingHandlerMapping handlerMapping;
+
+    public IdempotencyFilter(
+            IdempotencyEngine engine,
+            IdempotencyStore store,
+            IdempotencyConfig config,
+            RequestMappingHandlerMapping handlerMapping) {
+        this.engine = Objects.requireNonNull(engine, "engine must not be null");
+        this.store = Objects.requireNonNull(store, "store must not be null");
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.handlerMapping = Objects.requireNonNull(handlerMapping, "handlerMapping must not be null");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        Idempotent annotation = resolveAnnotation(request);
+        if (annotation == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String key = request.getHeader(config.keyHeader());
+        if (key == null || key.isBlank()) {
+            if (annotation.required()) {
+                writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, "Idempotency-Key header is required");
+                return;
+            }
+            chain.doFilter(request, response);
+            return;
+        }
+
+        Duration ttl = annotation.ttl().isEmpty() ? config.defaultTtl() : Duration.parse(annotation.ttl());
+        Duration lockTimeout = annotation.lockTimeout().isEmpty()
+                ? config.defaultLockTimeout()
+                : Duration.parse(annotation.lockTimeout());
+        IdempotencyContext context = new IdempotencyContext(key, ttl, lockTimeout);
+
+        ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+        ExecutionResult result;
+        try {
+            result = engine.execute(context, () -> chain.doFilter(request, wrappedResponse));
+        } catch (IdempotencyLockTimeoutException e) {
+            writeJsonError(
+                    response,
+                    HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+                    "Request with this key is already being processed");
+            return;
+        } catch (ServletException | IOException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+
+        switch (result) {
+            case ExecutionResult.Executed ignored -> {
+                StoredResponse storedResponse = new StoredResponse(
+                        wrappedResponse.getStatus(),
+                        collectHeaders(wrappedResponse),
+                        wrappedResponse.getContentAsByteArray(),
+                        Instant.now());
+                store.complete(context.key(), storedResponse, context.ttl());
+                wrappedResponse.copyBodyToResponse();
+            }
+            case ExecutionResult.Duplicate d -> {
+                StoredResponse stored = d.response();
+                response.setStatus(stored.statusCode());
+                stored.headers().forEach((name, values) -> values.forEach(value -> response.addHeader(name, value)));
+                response.setHeader("X-Idempotent-Replayed", "true");
+                response.getOutputStream().write(stored.body());
+            }
+        }
+    }
+
+    private Idempotent resolveAnnotation(HttpServletRequest request) {
+        HandlerExecutionChain handlerChain;
+        try {
+            handlerChain = handlerMapping.getHandler(request);
+        } catch (Exception e) {
+            return null;
+        }
+        if (handlerChain == null || !(handlerChain.getHandler() instanceof HandlerMethod handlerMethod)) {
+            return null;
+        }
+        return handlerMethod.getMethodAnnotation(Idempotent.class);
+    }
+
+    private Map<String, List<String>> collectHeaders(ContentCachingResponseWrapper response) {
+        Map<String, List<String>> headers = new HashMap<>();
+        response.getHeaderNames().forEach(name -> headers.put(name, new ArrayList<>(response.getHeaders(name))));
+        return headers;
+    }
+
+    private void writeJsonError(HttpServletResponse response, int status, String message) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"" + message + "\"}");
+    }
+}

--- a/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
+++ b/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.method.HandlerMethod;
@@ -57,7 +56,8 @@ public class IdempotencyFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain chain)
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain chain)
             throws ServletException, IOException {
         Idempotent annotation = resolveAnnotation(request);
         if (annotation == null) {
@@ -87,10 +87,7 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         try {
             result = engine.execute(context, () -> chain.doFilter(request, wrappedResponse));
         } catch (IdempotencyLockTimeoutException e) {
-            writeJsonError(
-                    response,
-                    HttpServletResponse.SC_SERVICE_UNAVAILABLE,
-                    ERROR_LOCK_TIMEOUT);
+            writeJsonError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, ERROR_LOCK_TIMEOUT);
             return;
         } catch (ServletException | IOException | RuntimeException e) {
             throw e;

--- a/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
+++ b/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
@@ -19,6 +19,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerExecutionChain;
@@ -36,6 +38,8 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
  */
 public class IdempotencyFilter extends OncePerRequestFilter {
 
+    private static final String ERROR_MISSING_KEY = "Idempotency-Key header is required";
+    private static final String ERROR_LOCK_TIMEOUT = "Request with this key is already being processed";
     private final IdempotencyEngine engine;
     private final IdempotencyStore store;
     private final IdempotencyConfig config;
@@ -53,7 +57,7 @@ public class IdempotencyFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain chain)
             throws ServletException, IOException {
         Idempotent annotation = resolveAnnotation(request);
         if (annotation == null) {
@@ -63,8 +67,9 @@ public class IdempotencyFilter extends OncePerRequestFilter {
 
         String key = request.getHeader(config.keyHeader());
         if (key == null || key.isBlank()) {
+            // annotation.required() is authoritative here; config.keyRequired() is for the starter layer
             if (annotation.required()) {
-                writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, "Idempotency-Key header is required");
+                writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, ERROR_MISSING_KEY);
                 return;
             }
             chain.doFilter(request, response);
@@ -85,11 +90,9 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             writeJsonError(
                     response,
                     HttpServletResponse.SC_SERVICE_UNAVAILABLE,
-                    "Request with this key is already being processed");
+                    ERROR_LOCK_TIMEOUT);
             return;
-        } catch (ServletException | IOException e) {
-            throw e;
-        } catch (RuntimeException e) {
+        } catch (ServletException | IOException | RuntimeException e) {
             throw e;
         } catch (Exception e) {
             throw new ServletException(e);

--- a/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/Idempotent.java
+++ b/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/Idempotent.java
@@ -1,0 +1,38 @@
+package io.github.josipmusa.idempotency.spring;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a Spring MVC handler method as idempotent.
+ *
+ * <p>When present, {@link IdempotencyFilter} will enforce idempotency for
+ * requests to this endpoint using the configured {@link io.github.josipmusa.core.IdempotencyStore}.
+ *
+ * <p>Attribute values override {@link io.github.josipmusa.core.IdempotencyConfig} defaults
+ * when non-empty.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Idempotent {
+
+    /**
+     * ISO-8601 duration for how long a completed response is kept.
+     * Empty string means use {@link io.github.josipmusa.core.IdempotencyConfig#defaultTtl()}.
+     */
+    String ttl() default "";
+
+    /**
+     * ISO-8601 duration for how long a concurrent caller waits.
+     * Empty string means use {@link io.github.josipmusa.core.IdempotencyConfig#defaultLockTimeout()}.
+     */
+    String lockTimeout() default "";
+
+    /**
+     * Whether a missing idempotency key header should be rejected with 400.
+     * When false, requests without a key pass through without idempotency enforcement.
+     */
+    boolean required() default true;
+}

--- a/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
+++ b/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import io.github.josipmusa.core.AcquireResult;
 import io.github.josipmusa.core.ExecutionResult;
 import io.github.josipmusa.core.IdempotencyConfig;
 import io.github.josipmusa.core.IdempotencyEngine;
@@ -89,10 +88,7 @@ class IdempotencyFilterTest {
 
     private StoredResponse storedResponse() {
         return new StoredResponse(
-                200,
-                Map.of("Content-Type", List.of("application/json")),
-                "{\"id\":\"1\"}".getBytes(),
-                Instant.now());
+                200, Map.of("Content-Type", List.of("application/json")), "{\"id\":\"1\"}".getBytes(), Instant.now());
     }
 
     // ---- tests ----

--- a/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
+++ b/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
@@ -1,0 +1,216 @@
+package io.github.josipmusa.idempotency.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.github.josipmusa.core.AcquireResult;
+import io.github.josipmusa.core.ExecutionResult;
+import io.github.josipmusa.core.IdempotencyConfig;
+import io.github.josipmusa.core.IdempotencyEngine;
+import io.github.josipmusa.core.IdempotencyStore;
+import io.github.josipmusa.core.StoredResponse;
+import io.github.josipmusa.core.ThrowingRunnable;
+import io.github.josipmusa.core.exception.IdempotencyLockTimeoutException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.annotation.Annotation;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+class IdempotencyFilterTest {
+
+    private IdempotencyEngine engine;
+    private IdempotencyStore store;
+    private IdempotencyConfig config;
+    private RequestMappingHandlerMapping handlerMapping;
+    private IdempotencyFilter filter;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        engine = mock(IdempotencyEngine.class);
+        store = mock(IdempotencyStore.class);
+        config = IdempotencyConfig.defaults();
+        handlerMapping = mock(RequestMappingHandlerMapping.class);
+        filter = new IdempotencyFilter(engine, store, config, handlerMapping);
+
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        filterChain = mock(FilterChain.class);
+    }
+
+    // ---- helpers ----
+
+    private void setupAnnotatedHandler(Idempotent annotation) throws Exception {
+        HandlerMethod handlerMethod = mock(HandlerMethod.class);
+        when(handlerMethod.getMethodAnnotation(Idempotent.class)).thenReturn(annotation);
+        HandlerExecutionChain chain = new HandlerExecutionChain(handlerMethod);
+        when(handlerMapping.getHandler(request)).thenReturn(chain);
+    }
+
+    private Idempotent annotation(boolean required) {
+        return new Idempotent() {
+            @Override
+            public String ttl() {
+                return "";
+            }
+
+            @Override
+            public String lockTimeout() {
+                return "";
+            }
+
+            @Override
+            public boolean required() {
+                return required;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return Idempotent.class;
+            }
+        };
+    }
+
+    private StoredResponse storedResponse() {
+        return new StoredResponse(
+                200,
+                Map.of("Content-Type", List.of("application/json")),
+                "{\"id\":\"1\"}".getBytes(),
+                Instant.now());
+    }
+
+    // ---- tests ----
+
+    @Test
+    void nonAnnotatedHandler_proceedsNormally() throws Exception {
+        HandlerMethod handlerMethod = mock(HandlerMethod.class);
+        when(handlerMethod.getMethodAnnotation(Idempotent.class)).thenReturn(null);
+        HandlerExecutionChain chain = new HandlerExecutionChain(handlerMethod);
+        when(handlerMapping.getHandler(request)).thenReturn(chain);
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verifyNoInteractions(engine);
+    }
+
+    @Test
+    void missingKeyAndRequired_returns400() throws Exception {
+        setupAnnotatedHandler(annotation(true));
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+        assertThat(response.getContentAsString()).isEqualTo("{\"error\": \"Idempotency-Key header is required\"}");
+        assertThat(response.getContentType()).isEqualTo("application/json");
+        verifyNoInteractions(engine);
+    }
+
+    @Test
+    void missingKeyAndNotRequired_proceedsNormally() throws Exception {
+        setupAnnotatedHandler(annotation(false));
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verifyNoInteractions(engine);
+    }
+
+    @Test
+    void executedResult_storesResponseAndCopiesBody() throws Exception {
+        setupAnnotatedHandler(annotation(true));
+        request.addHeader("Idempotency-Key", "test-key");
+
+        doAnswer(invocation -> {
+                    ThrowingRunnable action = invocation.getArgument(1);
+                    action.run();
+                    return ExecutionResult.executed();
+                })
+                .when(engine)
+                .execute(any(), any());
+
+        doAnswer(invocation -> {
+                    HttpServletResponse resp = (HttpServletResponse) invocation.getArgument(1);
+                    resp.setStatus(201);
+                    resp.setContentType("application/json");
+                    resp.getWriter().write("{\"id\":\"1\"}");
+                    return null;
+                })
+                .when(filterChain)
+                .doFilter(any(), any());
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(store).complete(eq("test-key"), any(StoredResponse.class), any(Duration.class));
+        assertThat(response.getContentAsString()).isEqualTo("{\"id\":\"1\"}");
+        assertThat(response.getStatus()).isEqualTo(201);
+    }
+
+    @Test
+    void duplicateResult_replaysStoredResponse() throws Exception {
+        setupAnnotatedHandler(annotation(true));
+        request.addHeader("Idempotency-Key", "test-key");
+        StoredResponse stored = storedResponse();
+        when(engine.execute(any(), any())).thenReturn(ExecutionResult.duplicate(stored));
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getContentAsByteArray()).isEqualTo("{\"id\":\"1\"}".getBytes());
+    }
+
+    @Test
+    void duplicateResult_setsReplayedHeader() throws Exception {
+        setupAnnotatedHandler(annotation(true));
+        request.addHeader("Idempotency-Key", "test-key");
+        when(engine.execute(any(), any())).thenReturn(ExecutionResult.duplicate(storedResponse()));
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getHeader("X-Idempotent-Replayed")).isEqualTo("true");
+    }
+
+    @Test
+    void lockTimeoutException_returns503() throws Exception {
+        setupAnnotatedHandler(annotation(true));
+        request.addHeader("Idempotency-Key", "test-key");
+        when(engine.execute(any(), any()))
+                .thenThrow(new IdempotencyLockTimeoutException("test-key", Duration.ofSeconds(10)));
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        assertThat(response.getContentAsString())
+                .isEqualTo("{\"error\": \"Request with this key is already being processed\"}");
+        assertThat(response.getContentType()).isEqualTo("application/json");
+    }
+
+    @Test
+    void actionThrows_releaseIsCalledByEngine() throws Exception {
+        setupAnnotatedHandler(annotation(true));
+        request.addHeader("Idempotency-Key", "test-key");
+        RuntimeException actionException = new RuntimeException("action failed");
+        when(engine.execute(any(), any())).thenThrow(actionException);
+
+        assertThatThrownBy(() -> filter.doFilter(request, response, filterChain))
+                .isSameAs(actionException);
+
+        verify(store, never()).release(any());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.14.2</mockito.version>
         <spring.version>6.2.3</spring.version>
+        <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
     </properties>
 
     <dependencyManagement>
@@ -55,6 +56,12 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-test</artifactId>
                 <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet-api.version}</version>
+                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <module>providers/idempotency-inmemory</module>
         <module>providers/idempotency-jdbc</module>
         <module>idempotency-test</module>
+        <module>idempotency-spring</module>
     </modules>
     <version>0.0.1-SNAPSHOT</version>
     <description>Idempotency Java Library</description>
@@ -25,6 +26,7 @@
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.14.2</mockito.version>
+        <spring.version>6.2.3</spring.version>
     </properties>
 
     <dependencyManagement>
@@ -43,6 +45,16 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-test</artifactId>
+                <version>${spring.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
                 <version>${jakarta.servlet-api.version}</version>
-                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary

  - Adds `idempotency-spring` Maven module — a Spring MVC adapter that bridges `OncePerRequestFilter` with `IdempotencyEngine`
  - `@Idempotent` annotation opts handler methods into idempotency enforcement; supports per-method `ttl`, `lockTimeout`, and `required` overrides
  - `IdempotencyFilter` resolves the matched handler via `RequestMappingHandlerMapping`, wraps the response with `ContentCachingResponseWrapper`, calls `engine.execute()`, then either stores the new response (`store.complete()`) or replays the stored one
   (`X-Idempotent-Replayed: true`)
  - Adds `keyHeader` field to `IdempotencyConfig` (default `"Idempotency-Key"`) so the adapter knows which header to read
  - No Spring Boot or store provider dependencies — wiring belongs in the future starter module

  ## Test Plan

  - [x] `mvn test -pl idempotency-spring -am` — 8 unit tests pass
  - [x] `mvn verify` — full build green across all modules
