### PR TITLE
Fix idempotency-spring open source review issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,8 @@ idempotency4j/
 │   └── idempotency-redis/   Redis implementation of IdempotencyStore.
 │                            Depends on core only. No Spring dependency.
 ├── idempotency-spring/      Spring MVC adapter. Depends on core +
-│                            Spring Web + Spring AOP. Contains
-│                            @Idempotent annotation and interceptor.
+│                            Spring Web. Contains @Idempotent annotation
+│                            and filter.
 └── idempotency-spring-boot-starter/  Autoconfiguration. Wires everything
                              together based on classpath detection.
 ```
@@ -40,7 +40,7 @@ These rules are strict. Do not violate them.
 - `idempotency-jdbc` depends on core only — no Spring
 - `idempotency-redis` depends on core only — no Spring
 - `idempotency-test` depends on idempotency-inmemory + JUnit 5 + AssertJ
-- `idempotency-spring` depends on core + Spring Web + Spring AOP
+- `idempotency-spring` depends on core + Spring Web
 - `idempotency-spring-boot-starter` depends on spring module + providers
 
 When adding dependencies to pom.xml - first think about where the version managing belongs.

--- a/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyConfig.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyConfig.java
@@ -14,8 +14,12 @@ import java.util.Objects;
  * <ul>
  *   <li>{@code defaultTtl} = 24 hours — how long completed responses are kept</li>
  *   <li>{@code defaultLockTimeout} = 10 seconds — how long a second caller waits</li>
- *   <li>{@code keyRequired} = true — whether requests without an idempotency key
- *       should be rejected (true) or passed through without idempotency (false)</li>
+ *   <li>{@code keyRequired} = true — global default for whether requests without an idempotency
+ *       key should be rejected (true) or passed through without idempotency (false).
+ *       <strong>Note:</strong> the {@code idempotency-spring} adapter does <em>not</em> read this
+ *       field. The {@link io.github.josipmusa.idempotency.spring.Idempotent#required()} attribute
+ *       on each handler method is authoritative in that adapter. This field is reserved for the
+ *       starter layer, which will use it as the default for routes that lack the annotation.</li>
  * </ul>
  */
 public final class IdempotencyConfig {

--- a/idempotency-spring/pom.xml
+++ b/idempotency-spring/pom.xml
@@ -24,6 +24,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
+++ b/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
@@ -12,6 +12,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -19,6 +20,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.lang.NonNull;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.method.HandlerMethod;
@@ -36,6 +39,8 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
  * <p>Do not annotate with {@code @Component} or {@code @Bean} — wiring belongs in the starter.
  */
 public class IdempotencyFilter extends OncePerRequestFilter {
+
+    private static final Log log = LogFactory.getLog(IdempotencyFilter.class);
 
     private static final String ERROR_MISSING_KEY = "Idempotency-Key header is required";
     private static final String ERROR_LOCK_TIMEOUT = "Request with this key is already being processed";
@@ -69,17 +74,15 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         if (key == null || key.isBlank()) {
             // annotation.required() is authoritative here; config.keyRequired() is for the starter layer
             if (annotation.required()) {
-                writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, ERROR_MISSING_KEY);
+                writeJsonError(response, 422, ERROR_MISSING_KEY);
                 return;
             }
             chain.doFilter(request, response);
             return;
         }
 
-        Duration ttl = annotation.ttl().isEmpty() ? config.defaultTtl() : Duration.parse(annotation.ttl());
-        Duration lockTimeout = annotation.lockTimeout().isEmpty()
-                ? config.defaultLockTimeout()
-                : Duration.parse(annotation.lockTimeout());
+        Duration ttl = parseDuration(annotation.ttl(), "ttl", config.defaultTtl());
+        Duration lockTimeout = parseDuration(annotation.lockTimeout(), "lockTimeout", config.defaultLockTimeout());
         IdempotencyContext context = new IdempotencyContext(key, ttl, lockTimeout);
 
         ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
@@ -102,8 +105,17 @@ public class IdempotencyFilter extends OncePerRequestFilter {
                         collectHeaders(wrappedResponse),
                         wrappedResponse.getContentAsByteArray(),
                         Instant.now());
-                store.complete(context.key(), storedResponse, context.ttl());
-                wrappedResponse.copyBodyToResponse();
+                try {
+                    store.complete(context.key(), storedResponse, context.ttl());
+                } catch (Exception e) {
+                    log.error(
+                            "Failed to store idempotency response for key '"
+                                    + context.key()
+                                    + "'; key will remain IN_PROGRESS until lock expires",
+                            e);
+                } finally {
+                    wrappedResponse.copyBodyToResponse();
+                }
             }
             case ExecutionResult.Duplicate d -> {
                 StoredResponse stored = d.response();
@@ -120,6 +132,10 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         try {
             handlerChain = handlerMapping.getHandler(request);
         } catch (Exception e) {
+            log.warn(
+                    "Could not resolve handler for request [" + request.getMethod() + " " + request.getRequestURI()
+                            + "]; skipping idempotency enforcement",
+                    e);
             return null;
         }
         if (handlerChain == null || !(handlerChain.getHandler() instanceof HandlerMethod handlerMethod)) {
@@ -137,6 +153,34 @@ public class IdempotencyFilter extends OncePerRequestFilter {
     private void writeJsonError(HttpServletResponse response, int status, String message) throws IOException {
         response.setStatus(status);
         response.setContentType("application/json");
-        response.getWriter().write("{\"error\": \"" + message + "\"}");
+        response.getWriter().write("{\"error\": \"" + escapeJson(message) + "\"}");
+    }
+
+    private static String escapeJson(String value) {
+        return value.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r");
+    }
+
+    /**
+     * Parses an ISO-8601 duration string from an {@link Idempotent} annotation attribute.
+     * Returns {@code defaultValue} when {@code raw} is empty.
+     *
+     * @throws IllegalArgumentException if {@code raw} is non-empty but not a valid ISO-8601 duration
+     */
+    private static Duration parseDuration(String raw, String attributeName, Duration defaultValue) {
+        if (raw.isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            return Duration.parse(raw);
+        } catch (DateTimeException e) {
+            throw new IllegalArgumentException(
+                    "@Idempotent(" + attributeName + " = \"" + raw
+                            + "\") is not a valid ISO-8601 duration (e.g. \"PT10S\", \"PT1H\"): "
+                            + e.getMessage(),
+                    e);
+        }
     }
 }

--- a/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/Idempotent.java
+++ b/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/Idempotent.java
@@ -1,5 +1,6 @@
 package io.github.josipmusa.idempotency.spring;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,6 +15,7 @@ import java.lang.annotation.Target;
  * <p>Attribute values override {@link io.github.josipmusa.core.IdempotencyConfig} defaults
  * when non-empty.
  */
+@Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Idempotent {
@@ -31,7 +33,7 @@ public @interface Idempotent {
     String lockTimeout() default "";
 
     /**
-     * Whether a missing idempotency key header should be rejected with 400.
+     * Whether a missing idempotency key header should be rejected with 422 Unprocessable Entity.
      * When false, requests without a key pass through without idempotency enforcement.
      */
     boolean required() default true;

--- a/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
+++ b/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
@@ -63,15 +63,19 @@ class IdempotencyFilterTest {
     }
 
     private Idempotent annotation(boolean required) {
+        return annotation(required, "", "");
+    }
+
+    private Idempotent annotation(boolean required, String ttl, String lockTimeout) {
         return new Idempotent() {
             @Override
             public String ttl() {
-                return "";
+                return ttl;
             }
 
             @Override
             public String lockTimeout() {
-                return "";
+                return lockTimeout;
             }
 
             @Override
@@ -107,12 +111,12 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void missingKeyAndRequired_returns400() throws Exception {
+    void missingKeyAndRequired_returns422() throws Exception {
         setupAnnotatedHandler(annotation(true));
 
         filter.doFilter(request, response, filterChain);
 
-        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+        assertThat(response.getStatus()).isEqualTo(422);
         assertThat(response.getContentAsString()).isEqualTo("{\"error\": \"Idempotency-Key header is required\"}");
         assertThat(response.getContentType()).isEqualTo("application/json");
         verifyNoInteractions(engine);
@@ -156,6 +160,35 @@ class IdempotencyFilterTest {
         verify(store).complete(eq("test-key"), any(StoredResponse.class), any(Duration.class));
         assertThat(response.getContentAsString()).isEqualTo("{\"id\":\"1\"}");
         assertThat(response.getStatus()).isEqualTo(201);
+    }
+
+    @Test
+    void annotationTtlOverride_passesCustomTtlToStore() throws Exception {
+        setupAnnotatedHandler(annotation(true, "PT2H", ""));
+        request.addHeader("Idempotency-Key", "test-key");
+
+        doAnswer(invocation -> {
+                    ThrowingRunnable action = invocation.getArgument(1);
+                    action.run();
+                    return ExecutionResult.executed();
+                })
+                .when(engine)
+                .execute(any(), any());
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(store).complete(eq("test-key"), any(StoredResponse.class), eq(Duration.ofHours(2)));
+    }
+
+    @Test
+    void annotationInvalidTtl_throwsIllegalArgumentException() throws Exception {
+        setupAnnotatedHandler(annotation(true, "2h", ""));
+        request.addHeader("Idempotency-Key", "test-key");
+
+        assertThatThrownBy(() -> filter.doFilter(request, response, filterChain))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("@Idempotent(ttl = \"2h\")")
+                .hasMessageContaining("PT");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Addresses issues found during open source readiness review of the `idempotency-spring` module:

- **`spring-webmvc` marked `optional`** — was forcing the full Spring MVC dependency tree onto every consumer; now follows standard library practice
- **Response body always flushed** — `store.complete()` failure no longer silently drops the HTTP response body; error is logged and body is always copied via `finally`
- **Missing key returns 422** — changed from 400 Bad Request to 422 Unprocessable Entity (matches stated design intent)
- **JSON escaping in error responses** — `writeJsonError` now uses an `escapeJson` helper to prevent future injection risk as the method evolves
- **Descriptive error for bad annotation durations** — `Duration.parse()` failures now produce `IllegalArgumentException` with the annotation attribute name and value, caught at request time with a clear message pointing to ISO-8601 format
- **WARN log for swallowed handler resolution exceptions** — `resolveAnnotation` no longer silently returns `null` on unexpected failures
- **`@Documented` on `@Idempotent`** — annotation now appears in generated Javadoc for annotated methods
- **`keyRequired()` Javadoc clarified** — documents that `idempotency-spring` does not read this field; reserved for the starter layer
- **CLAUDE.md corrected** — removed Spring AOP (not an actual dependency)

## Test plan

- [x] All 10 unit tests in `IdempotencyFilterTest` pass (`mvn test -pl idempotency-spring -am`)
- [x] New `annotationTtlOverride_passesCustomTtlToStore` test verifies annotation-level TTL override
- [x] New `annotationInvalidTtl_throwsIllegalArgumentException` test verifies descriptive error for invalid ISO-8601 strings
- [x] Full build passes (`mvn verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)