### PR TITLE
feat: add scheduled purge task to spring-boot-starter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ build/
 
 ### Mac OS ###
 .DS_Store
+# JDS AI working artifacts
+docs/jds/

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyProperties.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyProperties.java
@@ -12,6 +12,7 @@ public class IdempotencyProperties {
     private Duration defaultTtl = Duration.ofHours(24);
     private Duration defaultLockTimeout = Duration.ofSeconds(10);
     private int filterOrder = Ordered.HIGHEST_PRECEDENCE + 1;
+    private Purge purge = new Purge();
 
     public String getKeyHeader() {
         return keyHeader;
@@ -51,5 +52,35 @@ public class IdempotencyProperties {
 
     public void setFilterOrder(int filterOrder) {
         this.filterOrder = filterOrder;
+    }
+
+    public Purge getPurge() {
+        return purge;
+    }
+
+    public void setPurge(Purge purge) {
+        this.purge = purge;
+    }
+
+    public static class Purge {
+
+        private boolean enabled = true;
+        private String cron = "0 0 * * * *";
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getCron() {
+            return cron;
+        }
+
+        public void setCron(String cron) {
+            this.cron = cron;
+        }
     }
 }

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeConfiguration.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeConfiguration.java
@@ -1,0 +1,30 @@
+package io.github.josipmusa.idempotency.springboot;
+
+import io.github.josipmusa.core.IdempotencyStore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnBean(IdempotencyStore.class)
+@ConditionalOnProperty(
+        prefix = "idempotency.purge",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class IdempotencyPurgeConfiguration {
+
+    private final IdempotencyStore store;
+
+    public IdempotencyPurgeConfiguration(IdempotencyStore store) {
+        this.store = store;
+    }
+
+    @Scheduled(cron = "${idempotency.purge.cron:0 0 * * * *}")
+    public void purgeExpired() {
+        store.purgeExpired();
+    }
+}

--- a/spring/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 io.github.josipmusa.idempotency.springboot.IdempotencyAutoConfiguration
+io.github.josipmusa.idempotency.springboot.IdempotencyPurgeConfiguration

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeConfigurationTest.java
@@ -1,0 +1,64 @@
+package io.github.josipmusa.idempotency.springboot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.github.josipmusa.core.IdempotencyStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class IdempotencyPurgeConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(IdempotencyPurgeConfiguration.class));
+
+    @Test
+    void When_NoStoreBeanPresent_Expect_PurgeConfigurationNotCreated() {
+        contextRunner.run(context -> assertThat(context).doesNotHaveBean(IdempotencyPurgeConfiguration.class));
+    }
+
+    @Test
+    void When_StoreBeanPresent_Expect_PurgeConfigurationCreated() {
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
+                .run(context -> assertThat(context).hasSingleBean(IdempotencyPurgeConfiguration.class));
+    }
+
+    @Test
+    void When_PurgeDisabled_Expect_PurgeConfigurationNotCreated() {
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
+                .withPropertyValues("idempotency.purge.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(IdempotencyPurgeConfiguration.class));
+    }
+
+    @Test
+    void When_PurgeEnabledExplicitly_Expect_PurgeConfigurationCreated() {
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
+                .withPropertyValues("idempotency.purge.enabled=true")
+                .run(context -> assertThat(context).hasSingleBean(IdempotencyPurgeConfiguration.class));
+    }
+
+    @Test
+    void When_PurgeExpiredCalled_Expect_StorePurgeExpiredInvoked() {
+        IdempotencyStore store = mock(IdempotencyStore.class);
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> store)
+                .run(context -> {
+                    IdempotencyPurgeConfiguration config = context.getBean(IdempotencyPurgeConfiguration.class);
+                    config.purgeExpired();
+                    verify(store).purgeExpired();
+                });
+    }
+
+    @Test
+    void When_CustomCronProvided_Expect_PurgeConfigurationCreated() {
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
+                .withPropertyValues("idempotency.purge.cron=0 0 2 * * *")
+                .run(context -> assertThat(context).hasSingleBean(IdempotencyPurgeConfiguration.class));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a configurable scheduled task to `IdempotencyAutoConfiguration` that periodically calls `purgeExpired()` on the `IdempotencyStore`.

## Changes

### `IdempotencyProperties`
Added nested `Purge` static inner class binding to `idempotency.purge.*`:
- `enabled` (default `true`) — toggles the scheduled task on/off
- `cron` (default `"0 0 * * * *"`) — standard cron expression (hourly by default)

### `IdempotencyPurgeConfiguration` (new)
A separate `@Configuration` class (purge concerns isolated from `IdempotencyAutoConfiguration`) that:
- Is conditional on `IdempotencyStore` bean being present (`@ConditionalOnBean`)
- Is conditional on `idempotency.purge.enabled=true` with `matchIfMissing=true` so it is active by default
- Enables scheduling via `@EnableScheduling`
- Exposes a single `@Scheduled` method that calls `store.purgeExpired()` using the configured cron expression

### `AutoConfiguration.imports`
Registered `IdempotencyPurgeConfiguration` alongside `IdempotencyAutoConfiguration`.

## Configuration

```yaml
idempotency:
  purge:
    enabled: true          # default — set to false to disable
    cron: "0 0 * * * *"   # default hourly; any valid Spring cron expression
```

## Tests

6 new tests in `IdempotencyPurgeConfigurationTest`:
1. No store bean → purge configuration not created
2. Store bean present → purge configuration created (default config)
3. `purge.enabled=false` → purge configuration not created
4. `purge.enabled=true` explicitly → purge configuration created
5. `purgeExpired()` method delegates to `IdempotencyStore.purgeExpired()`
6. Custom cron expression → purge configuration still created