### PR TITLE
feat: add scheduled purge autoconfiguration to spring-boot-starter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+# JDS AI working artifacts
+docs/jds/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,11 @@ are intentionally left in place — they are still eligible for lock
 stealing by the next `tryAcquire` caller.
 
 Scheduling is never the store's responsibility. The Spring Boot starter
-wires a `@Scheduled` task to this method using the cron expression
-defined by `idempotency.purge-cron` (default: hourly). In plain Java
-usage, the caller schedules it manually with a
+registers a `SchedulingConfigurer` bean that adds a cron task calling
+this method using the expression defined by `idempotency.purge.cron`
+(default: `"0 0 * * * *"`, hourly). The configurer is inert if the
+application has not enabled `@EnableScheduling`. In plain Java usage,
+the caller schedules it manually with a
 `ScheduledExecutorService`.
 
 No store implementation may self-schedule — no internal reaper threads.
@@ -157,11 +159,11 @@ and must not throw.
 
 ### Naming
 
-All test methods follow the `Context_ExpectedResult` pattern:
+All test methods follow the `When_<Context>_Expect_<Result>` pattern:
 ```
-newKey_returnsAcquired
-completedKey_returnsDuplicateWithCorrectResponse
-staleLock_isStolen
+When_NewKey_Expect_ReturnsAcquired
+When_CompletedKey_Expect_ReturnsDuplicateWithCorrectResponse
+When_StaleLock_Expect_IsStolen
 ```
 
 ### Contract tests
@@ -260,7 +262,7 @@ This includes the explanations and the current implementation status.
 - providers/idempotency-jdbc (JdbcIdempotencyStore with Testcontainers MySQL tests)
 - idempotency-test (IdempotencyStoreContract)
 - idempotency-spring (IdempotencyFilter + @Idempotent annotation)
-- idempotency-spring-boot-starter (IdempotencyAutoConfiguration)
+- idempotency-spring-boot-starter (IdempotencyAutoConfiguration + IdempotencyPurgeAutoConfiguration)
 
 ### Not started — do not implement
 - providers/idempotency-redis

--- a/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyConfigTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyConfigTest.java
@@ -8,19 +8,19 @@ import org.junit.jupiter.api.Test;
 class IdempotencyConfigTest {
 
     @Test
-    void defaults_keyHeaderIsIdempotencyKey() {
+    void When_DefaultsUsed_Expect_KeyHeaderIsIdempotencyKey() {
         assertThat(IdempotencyConfig.defaults().keyHeader()).isEqualTo("Idempotency-Key");
     }
 
     @Test
-    void builder_customKeyHeader() {
+    void When_CustomKeyHeaderSet_Expect_KeyHeaderIsCustom() {
         IdempotencyConfig config =
                 IdempotencyConfig.builder().keyHeader("X-Request-Id").build();
         assertThat(config.keyHeader()).isEqualTo("X-Request-Id");
     }
 
     @Test
-    void builder_blankKeyHeader_throws() {
+    void When_BlankKeyHeaderProvided_Expect_ThrowsIllegalArgumentException() {
         assertThatThrownBy(() -> IdempotencyConfig.builder().keyHeader("  ").build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("keyHeader must not be blank");

--- a/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyEngineTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyEngineTest.java
@@ -48,7 +48,7 @@ class IdempotencyEngineTest {
     }
 
     @Test
-    void newKey_returnsExecuted() throws Exception {
+    void When_NewKey_Expect_ReturnsExecuted() throws Exception {
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
         ExecutionResult result = engine.execute(defaultContext("new-key"), () -> {});
@@ -57,7 +57,7 @@ class IdempotencyEngineTest {
     }
 
     @Test
-    void completedKey_returnsDuplicate() throws Exception {
+    void When_CompletedKey_Expect_ReturnsDuplicate() throws Exception {
         StoredResponse response = anyStoredResponse();
         when(store.tryAcquire(any())).thenReturn(AcquireResult.duplicate(response));
 
@@ -69,7 +69,7 @@ class IdempotencyEngineTest {
     }
 
     @Test
-    void completedKey_actionNotCalledOnDuplicate() throws Exception {
+    void When_CompletedKey_Expect_ActionNotCalled() throws Exception {
         when(store.tryAcquire(any())).thenReturn(AcquireResult.duplicate(anyStoredResponse()));
         AtomicInteger counter = new AtomicInteger(0);
 
@@ -79,7 +79,7 @@ class IdempotencyEngineTest {
     }
 
     @Test
-    void actionThrows_releaseIsCalled() {
+    void When_ActionThrows_Expect_ReleaseIsCalled() {
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
         String key = "fail-key";
 
@@ -94,7 +94,7 @@ class IdempotencyEngineTest {
     }
 
     @Test
-    void actionThrows_completeIsNeverCalled() {
+    void When_ActionThrows_Expect_CompleteNeverCalled() {
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
         try {
@@ -108,7 +108,7 @@ class IdempotencyEngineTest {
     }
 
     @Test
-    void actionThrows_originalExceptionPropagates() {
+    void When_ActionThrows_Expect_OriginalExceptionPropagates() {
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
         RuntimeException expected = new RuntimeException("specific failure");
 
@@ -119,7 +119,7 @@ class IdempotencyEngineTest {
     }
 
     @Test
-    void lockTimeout_throwsIdempotencyLockTimeoutException() {
+    void When_LockTimeout_Expect_ThrowsLockTimeoutException() {
         when(store.tryAcquire(any())).thenReturn(AcquireResult.lockTimeout("test-key"));
 
         assertThatThrownBy(() -> engine.execute(defaultContext("test-key"), () -> {}))
@@ -131,7 +131,7 @@ class IdempotencyEngineTest {
     }
 
     @Test
-    void heartbeat_extendLockCalledDuringLongRunningAction() throws Exception {
+    void When_LongRunningAction_Expect_HeartbeatExtendsLock() throws Exception {
         IdempotencyContext context = new IdempotencyContext("hb-key", Duration.ofHours(1), Duration.ofMillis(100));
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
@@ -141,7 +141,7 @@ class IdempotencyEngineTest {
     }
 
     @Test
-    void heartbeat_stopsAfterActionCompletes() throws Exception {
+    void When_ActionCompletes_Expect_HeartbeatStops() throws Exception {
         IdempotencyContext context = new IdempotencyContext("hb-stop-key", Duration.ofHours(1), Duration.ofMillis(100));
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
@@ -165,7 +165,7 @@ class IdempotencyEngineTest {
     }
 
     @Test
-    void heartbeat_stopsAfterActionThrows() throws Exception {
+    void When_ActionThrows_Expect_HeartbeatStops() throws Exception {
         IdempotencyContext context =
                 new IdempotencyContext("hb-throw-key", Duration.ofHours(1), Duration.ofMillis(100));
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
@@ -195,7 +195,7 @@ class IdempotencyEngineTest {
     // --- Context forwarding ---
 
     @Test
-    void execute_forwardsContextToStore() throws Exception {
+    void When_Execute_Expect_ContextForwardedToStore() throws Exception {
         IdempotencyContext context = defaultContext("forwarded-key");
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
@@ -207,7 +207,7 @@ class IdempotencyEngineTest {
     // --- Checked exception propagation ---
 
     @Test
-    void actionThrowsCheckedException_propagatesUnwrapped() {
+    void When_ActionThrowsCheckedException_Expect_PropagatesUnwrapped() {
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
         IOException expected = new IOException("disk full");
 
@@ -220,7 +220,7 @@ class IdempotencyEngineTest {
     // --- Cascading failure: release throws after action failure ---
 
     @Test
-    void actionThrowsAndReleaseFails_originalExceptionPropagates() {
+    void When_ActionThrowsAndReleaseFails_Expect_OriginalExceptionPropagates() {
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
         RuntimeException actionException = new RuntimeException("action failed");
         IdempotencyStoreException releaseException = new IdempotencyStoreException("store unreachable");
@@ -236,7 +236,7 @@ class IdempotencyEngineTest {
     // --- Store failure on tryAcquire ---
 
     @Test
-    void storeThrowsOnTryAcquire_propagatesDirectly() {
+    void When_StoreThrowsOnTryAcquire_Expect_PropagatesDirectly() {
         IdempotencyStoreException storeFailure = new IdempotencyStoreException("connection refused");
         when(store.tryAcquire(any())).thenThrow(storeFailure);
 

--- a/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
+++ b/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
@@ -39,14 +39,14 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void newKey_returnsAcquired() {
+    void When_NewKey_Expect_ReturnsAcquired() {
         AcquireResult result = store().tryAcquire(contextFor("new-key"));
 
         assertThat(result).isInstanceOf(AcquireResult.Acquired.class);
     }
 
     @Test
-    void completedKey_returnsDuplicateWithCorrectResponse() {
+    void When_CompletedKey_Expect_ReturnsDuplicateWithCorrectResponse() {
         IdempotencyStore s = store();
         String key = "complete-key";
         StoredResponse response = sampleResponse();
@@ -64,7 +64,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void releasedKey_canBeAcquiredAgain() {
+    void When_ReleasedKey_Expect_CanBeAcquiredAgain() {
         IdempotencyStore s = store();
         String key = "release-key";
 
@@ -77,7 +77,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void expiredKey_treatedAsNew() throws InterruptedException {
+    void When_ExpiredKey_Expect_TreatedAsNew() throws InterruptedException {
         IdempotencyStore s = store();
         String key = "expired-key";
 
@@ -92,7 +92,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void staleLock_isStolen() throws InterruptedException {
+    void When_StaleLock_Expect_IsStolen() throws InterruptedException {
         IdempotencyStore s = store();
         String key = "stale-key";
 
@@ -107,7 +107,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void inFlightKey_blocksAndReturnsDuplicateAfterCompletion() throws Exception {
+    void When_InFlightKey_Expect_BlocksAndReturnsDuplicateAfterCompletion() throws Exception {
         IdempotencyStore s = store();
         String key = "inflight-key";
         StoredResponse response = sampleResponse();
@@ -151,7 +151,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void inFlightKey_lockTimeoutExceeded_returnsLockTimeout() throws Exception {
+    void When_InFlightKeyLockTimeoutExceeded_Expect_ReturnsLockTimeout() throws Exception {
         IdempotencyStore s = store();
         String key = "timeout-key";
 
@@ -185,7 +185,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void concurrentRequests_onlyOneAcquires() throws Exception {
+    void When_ConcurrentRequests_Expect_OnlyOneAcquires() throws Exception {
         IdempotencyStore s = store();
         String key = "concurrent-key";
         StoredResponse response = sampleResponse();
@@ -247,7 +247,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void differentKeys_acquireIndependently() throws Exception {
+    void When_DifferentKeys_Expect_AcquireIndependently() throws Exception {
         IdempotencyStore s = store();
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -266,7 +266,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void releaseAllowsRetry_actionCanSucceedOnSecondAttempt() {
+    void When_ReleaseAllowsRetry_Expect_ActionCanSucceedOnSecondAttempt() {
         IdempotencyStore s = store();
         String key = "retry-key";
         StoredResponse response = sampleResponse();
@@ -292,7 +292,7 @@ public abstract class IdempotencyStoreContract {
     // --- extendLock contract ---
 
     @Test
-    void extendLock_inProgressKey_preventsLockFromBeingStolen() throws Exception {
+    void When_ExtendLockInProgressKey_Expect_LockNotStolen() throws Exception {
         IdempotencyStore s = store();
         String key = "extend-key";
 
@@ -320,7 +320,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void extendLock_unknownKey_silentlyIgnored() {
+    void When_ExtendLockUnknownKey_Expect_SilentlyIgnored() {
         IdempotencyStore s = store();
 
         // Must not throw — heartbeat may fire after key is already gone
@@ -328,7 +328,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void extendLock_completedKey_silentlyIgnored() {
+    void When_ExtendLockCompletedKey_Expect_SilentlyIgnored() {
         IdempotencyStore s = store();
         String key = "completed-extend-key";
         StoredResponse response = sampleResponse();
@@ -347,7 +347,7 @@ public abstract class IdempotencyStoreContract {
     // --- TTL durability ---
 
     @Test
-    void completedKey_returnsDuplicateWithinTtlWindow() {
+    void When_CompletedKeyWithinTtl_Expect_ReturnsDuplicate() {
         IdempotencyStore s = store();
         String key = "ttl-durable-key";
         StoredResponse response = sampleResponse();
@@ -366,7 +366,7 @@ public abstract class IdempotencyStoreContract {
     // --- Error contracts ---
 
     @Test
-    void completeOnNonExistentKey_throwsStoreException() {
+    void When_CompleteOnNonExistentKey_Expect_ThrowsStoreException() {
         IdempotencyStore s = store();
 
         assertThatThrownBy(() -> s.complete("ghost-key", sampleResponse(), Duration.ofHours(1)))
@@ -374,7 +374,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void completeOnReleasedKey_throwsStoreException() {
+    void When_CompleteOnReleasedKey_Expect_ThrowsStoreException() {
         IdempotencyStore s = store();
         String key = "failed-key";
 
@@ -386,14 +386,14 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void releaseOnNonExistentKey_throwsStoreException() {
+    void When_ReleaseOnNonExistentKey_Expect_ThrowsStoreException() {
         IdempotencyStore s = store();
 
         assertThatThrownBy(() -> s.release("ghost-key")).isInstanceOf(IdempotencyStoreException.class);
     }
 
     @Test
-    void completeOnCompletedKey_throwsStoreException() {
+    void When_CompleteOnCompletedKey_Expect_ThrowsStoreException() {
         IdempotencyStore s = store();
         String key = "double-complete-key";
 
@@ -405,7 +405,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void releaseOnCompletedKey_throwsStoreException() {
+    void When_ReleaseOnCompletedKey_Expect_ThrowsStoreException() {
         IdempotencyStore s = store();
         String key = "release-completed-key";
 
@@ -418,7 +418,7 @@ public abstract class IdempotencyStoreContract {
     // --- Full lifecycle ---
 
     @Test
-    void fullLifecycle_acquireCompleteTtlExpiresReacquireCompletes() throws InterruptedException {
+    void When_FullLifecycle_Expect_AcquireCompleteTtlExpiresReacquireCompletes() throws InterruptedException {
         IdempotencyStore s = store();
         String key = "lifecycle-key";
 
@@ -452,7 +452,7 @@ public abstract class IdempotencyStoreContract {
     // --- Additional edge-case contracts ---
 
     @Test
-    void extendLock_failedKey_silentlyIgnored() {
+    void When_ExtendLockFailedKey_Expect_SilentlyIgnored() {
         IdempotencyStore s = store();
         String key = "failed-extend-key";
 
@@ -464,7 +464,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void releaseOnReleasedKey_throwsStoreException() {
+    void When_ReleaseOnReleasedKey_Expect_ThrowsStoreException() {
         IdempotencyStore s = store();
         String key = "double-release-key";
 
@@ -475,7 +475,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void failedKeyUnderContention_timeoutRespected() throws Exception {
+    void When_FailedKeyUnderContention_Expect_TimeoutRespected() throws Exception {
         IdempotencyStore s = store();
         String key = "contended-failed-key";
         int chaosThreadCount = 20;
@@ -517,7 +517,7 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
-    void acquiredKey_secondAcquireTimesOut() {
+    void When_AcquiredKey_Expect_SecondAcquireTimesOut() {
         IdempotencyStore s = store();
         String key = "self-deadlock-key";
 

--- a/providers/idempotency-jdbc/src/test/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStoreTest.java
+++ b/providers/idempotency-jdbc/src/test/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStoreTest.java
@@ -43,12 +43,12 @@ class JdbcIdempotencyStoreTest extends IdempotencyStoreContract {
     }
 
     @Test
-    void initSchema_calledTwice_doesNotThrow() {
+    void When_InitSchemaCalledTwice_Expect_DoesNotThrow() {
         assertThatCode(() -> new JdbcIdempotencyStore(dataSource, true)).doesNotThrowAnyException();
     }
 
     @Test
-    void connectionExhausted_throwsIdempotencyStoreException() throws Exception {
+    void When_ConnectionExhausted_Expect_ThrowsIdempotencyStoreException() throws Exception {
         DataSource exhaustedDs = mock(DataSource.class);
         when(exhaustedDs.getConnection()).thenThrow(new SQLException("connection pool exhausted", "08001"));
 

--- a/spring/idempotency-spring-boot-starter/pom.xml
+++ b/spring/idempotency-spring-boot-starter/pom.xml
@@ -45,6 +45,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyProperties.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyProperties.java
@@ -12,6 +12,7 @@ public class IdempotencyProperties {
     private Duration defaultTtl = Duration.ofHours(24);
     private Duration defaultLockTimeout = Duration.ofSeconds(10);
     private int filterOrder = Ordered.HIGHEST_PRECEDENCE + 1;
+    private Purge purge = new Purge();
 
     public String getKeyHeader() {
         return keyHeader;
@@ -51,5 +52,35 @@ public class IdempotencyProperties {
 
     public void setFilterOrder(int filterOrder) {
         this.filterOrder = filterOrder;
+    }
+
+    public Purge getPurge() {
+        return purge;
+    }
+
+    public void setPurge(Purge purge) {
+        this.purge = purge;
+    }
+
+    public static class Purge {
+
+        private boolean enabled = true;
+        private String cron = "0 0 * * * *";
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getCron() {
+            return cron;
+        }
+
+        public void setCron(String cron) {
+            this.cron = cron;
+        }
     }
 }

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfiguration.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfiguration.java
@@ -1,0 +1,46 @@
+package io.github.josipmusa.idempotency.springboot;
+
+import io.github.josipmusa.core.IdempotencyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.support.CronExpression;
+
+@AutoConfiguration(after = IdempotencyAutoConfiguration.class)
+@ConditionalOnBean(IdempotencyStore.class)
+@ConditionalOnProperty(
+        prefix = "idempotency.purge",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+@EnableConfigurationProperties(IdempotencyProperties.class)
+public class IdempotencyPurgeAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(IdempotencyPurgeAutoConfiguration.class);
+
+    @Bean
+    public SchedulingConfigurer idempotencyPurgeSchedulingConfigurer(
+            IdempotencyStore store, IdempotencyProperties properties) {
+        String cron = properties.getPurge().getCron();
+        try {
+            CronExpression.parse(cron);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Invalid idempotency.purge.cron value: '" + cron + "'");
+        }
+        return taskRegistrar -> taskRegistrar.addCronTask(
+                () -> {
+                    try {
+                        store.purgeExpired();
+                    } catch (Exception e) {
+                        log.error("Idempotency purge task failed", e);
+                    }
+                },
+                cron);
+    }
+}

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfiguration.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfiguration.java
@@ -13,11 +13,7 @@ import org.springframework.scheduling.support.CronExpression;
 
 @AutoConfiguration(after = IdempotencyAutoConfiguration.class)
 @ConditionalOnBean(IdempotencyStore.class)
-@ConditionalOnProperty(
-        prefix = "idempotency.purge",
-        name = "enabled",
-        havingValue = "true",
-        matchIfMissing = true)
+@ConditionalOnProperty(prefix = "idempotency.purge", name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(IdempotencyProperties.class)
 public class IdempotencyPurgeAutoConfiguration {
 
@@ -30,8 +26,7 @@ public class IdempotencyPurgeAutoConfiguration {
         try {
             CronExpression.parse(cron);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException(
-                    "Invalid idempotency.purge.cron value: '" + cron + "'");
+            throw new IllegalArgumentException("Invalid idempotency.purge.cron value: '" + cron + "'");
         }
         return taskRegistrar -> taskRegistrar.addCronTask(
                 () -> {

--- a/spring/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring/idempotency-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 io.github.josipmusa.idempotency.springboot.IdempotencyAutoConfiguration
+io.github.josipmusa.idempotency.springboot.IdempotencyPurgeAutoConfiguration

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
@@ -23,7 +23,7 @@ class IdempotencyAutoConfigurationTest {
             .withBean(RequestMappingHandlerMapping.class, () -> mock(RequestMappingHandlerMapping.class));
 
     @Test
-    void noStoreBeanPresent_engineAndFilterNotCreated() {
+    void When_NoStoreBeanPresent_Expect_EngineAndFilterNotCreated() {
         contextRunner.run(context -> {
             assertThat(context).doesNotHaveBean(IdempotencyEngine.class);
             assertThat(context).doesNotHaveBean(IdempotencyFilter.class);
@@ -32,7 +32,7 @@ class IdempotencyAutoConfigurationTest {
     }
 
     @Test
-    void storeBeanPresent_engineAndFilterCreated() {
+    void When_StoreBeanPresent_Expect_EngineAndFilterCreated() {
         contextRunner
                 .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
                 .run(context -> {
@@ -43,7 +43,7 @@ class IdempotencyAutoConfigurationTest {
     }
 
     @Test
-    void customEngineBeanPresent_autoConfiguredEngineSkipped() {
+    void When_CustomEngineBeanPresent_Expect_AutoConfiguredEngineSkipped() {
         IdempotencyEngine customEngine = mock(IdempotencyEngine.class);
         contextRunner
                 .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
@@ -55,7 +55,7 @@ class IdempotencyAutoConfigurationTest {
     }
 
     @Test
-    void customConfigBeanPresent_autoConfiguredConfigSkipped() {
+    void When_CustomConfigBeanPresent_Expect_AutoConfiguredConfigSkipped() {
         IdempotencyConfig customConfig =
                 IdempotencyConfig.builder().keyHeader("X-Custom-Key").build();
         contextRunner.withBean(IdempotencyConfig.class, () -> customConfig).run(context -> {
@@ -65,7 +65,7 @@ class IdempotencyAutoConfigurationTest {
     }
 
     @Test
-    void customFilterBeanPresent_autoConfiguredFilterSkipped() {
+    void When_CustomFilterBeanPresent_Expect_AutoConfiguredFilterSkipped() {
         contextRunner
                 .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
                 .withBean(IdempotencyFilter.class, () -> mock(IdempotencyFilter.class))
@@ -73,7 +73,7 @@ class IdempotencyAutoConfigurationTest {
     }
 
     @Test
-    void defaultProperties_appliedToConfig() {
+    void When_DefaultProperties_Expect_AppliedToConfig() {
         contextRunner.run(context -> {
             IdempotencyConfig config = context.getBean(IdempotencyConfig.class);
             assertThat(config.keyHeader()).isEqualTo("Idempotency-Key");
@@ -83,7 +83,7 @@ class IdempotencyAutoConfigurationTest {
     }
 
     @Test
-    void customProperties_appliedToConfig() {
+    void When_CustomProperties_Expect_AppliedToConfig() {
         contextRunner
                 .withPropertyValues(
                         "idempotency.key-header=X-Request-Id",
@@ -98,7 +98,7 @@ class IdempotencyAutoConfigurationTest {
     }
 
     @Test
-    void defaultFilterOrder_appliedToRegistration() {
+    void When_DefaultFilterOrder_Expect_AppliedToRegistration() {
         contextRunner
                 .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
                 .run(context -> {
@@ -108,7 +108,7 @@ class IdempotencyAutoConfigurationTest {
     }
 
     @Test
-    void customFilterOrder_appliedToRegistration() {
+    void When_CustomFilterOrder_Expect_AppliedToRegistration() {
         contextRunner
                 .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
                 .withPropertyValues("idempotency.filter-order=10")
@@ -119,7 +119,7 @@ class IdempotencyAutoConfigurationTest {
     }
 
     @Test
-    void nonServletApplication_noBeanCreated() {
+    void When_NonServletApplication_Expect_NoBeanCreated() {
         new ApplicationContextRunner()
                 .withConfiguration(AutoConfigurations.of(IdempotencyAutoConfiguration.class))
                 .run(context -> {

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfigurationTest.java
@@ -1,0 +1,86 @@
+package io.github.josipmusa.idempotency.springboot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.github.josipmusa.core.IdempotencyStore;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+class IdempotencyPurgeAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(IdempotencyPurgeAutoConfiguration.class));
+
+    @Test
+    void When_StoreBeanPresent_Expect_PurgeConfigurerCreatedByDefault() {
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
+                .run(context -> assertThat(context).hasSingleBean(SchedulingConfigurer.class));
+    }
+
+    @Test
+    void When_PurgeDisabled_Expect_PurgeConfigurerNotCreated() {
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
+                .withPropertyValues("idempotency.purge.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(SchedulingConfigurer.class));
+    }
+
+    @Test
+    void When_NoStoreBeanPresent_Expect_PurgeConfigurerNotCreated() {
+        contextRunner.run(context -> assertThat(context).doesNotHaveBean(SchedulingConfigurer.class));
+    }
+
+    @Test
+    void When_CustomCronExpression_Expect_BeanCreatedWithCustomCron() {
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
+                .withPropertyValues("idempotency.purge.cron=0 0 12 * * *")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(SchedulingConfigurer.class);
+                    assertThat(context.getBean(IdempotencyProperties.class).getPurge().getCron())
+                            .isEqualTo("0 0 12 * * *");
+                });
+    }
+
+    @Test
+    void When_InvalidCronExpression_Expect_ContextStartupFails() {
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
+                .withPropertyValues("idempotency.purge.cron=not-a-cron")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                            .hasRootCauseMessage("Invalid idempotency.purge.cron value: 'not-a-cron'");
+                });
+    }
+
+    @Test
+    void When_PurgeExpiredThrows_Expect_ExceptionSwallowed() {
+        IdempotencyStore throwingStore = mock(IdempotencyStore.class);
+        doThrow(new RuntimeException("DB connection lost")).when(throwingStore).purgeExpired();
+
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> throwingStore)
+                .run(context -> {
+                    SchedulingConfigurer configurer = context.getBean(SchedulingConfigurer.class);
+                    ScheduledTaskRegistrar registrar = mock(ScheduledTaskRegistrar.class);
+                    configurer.configureTasks(registrar);
+
+                    ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+                    verify(registrar).addCronTask(taskCaptor.capture(), anyString());
+
+                    assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
+                });
+    }
+}

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfigurationTest.java
@@ -47,7 +47,9 @@ class IdempotencyPurgeAutoConfigurationTest {
                 .withPropertyValues("idempotency.purge.cron=0 0 12 * * *")
                 .run(context -> {
                     assertThat(context).hasSingleBean(SchedulingConfigurer.class);
-                    assertThat(context.getBean(IdempotencyProperties.class).getPurge().getCron())
+                    assertThat(context.getBean(IdempotencyProperties.class)
+                                    .getPurge()
+                                    .getCron())
                             .isEqualTo("0 0 12 * * *");
                 });
     }
@@ -70,17 +72,15 @@ class IdempotencyPurgeAutoConfigurationTest {
         IdempotencyStore throwingStore = mock(IdempotencyStore.class);
         doThrow(new RuntimeException("DB connection lost")).when(throwingStore).purgeExpired();
 
-        contextRunner
-                .withBean(IdempotencyStore.class, () -> throwingStore)
-                .run(context -> {
-                    SchedulingConfigurer configurer = context.getBean(SchedulingConfigurer.class);
-                    ScheduledTaskRegistrar registrar = mock(ScheduledTaskRegistrar.class);
-                    configurer.configureTasks(registrar);
+        contextRunner.withBean(IdempotencyStore.class, () -> throwingStore).run(context -> {
+            SchedulingConfigurer configurer = context.getBean(SchedulingConfigurer.class);
+            ScheduledTaskRegistrar registrar = mock(ScheduledTaskRegistrar.class);
+            configurer.configureTasks(registrar);
 
-                    ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
-                    verify(registrar).addCronTask(taskCaptor.capture(), anyString());
+            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+            verify(registrar).addCronTask(taskCaptor.capture(), anyString());
 
-                    assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
-                });
+            assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
+        });
     }
 }

--- a/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
+++ b/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
@@ -51,7 +51,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void nonAnnotatedHandler_proceedsNormally() throws Exception {
+    void When_NonAnnotatedHandler_Expect_ProceedsNormally() throws Exception {
         HandlerMethod handlerMethod = mock(HandlerMethod.class);
         when(handlerMethod.getMethodAnnotation(Idempotent.class)).thenReturn(null);
         HandlerExecutionChain chain = new HandlerExecutionChain(handlerMethod);
@@ -65,7 +65,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void missingKeyAndRequired_returns422() throws Exception {
+    void When_MissingKeyAndRequired_Expect_Returns422() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
 
         filter.doFilter(request, response, filterChain);
@@ -77,7 +77,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void missingKeyAndNotRequired_proceedsNormally() throws Exception {
+    void When_MissingKeyAndNotRequired_Expect_ProceedsNormally() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(false));
 
         filter.doFilter(request, response, filterChain);
@@ -87,7 +87,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void executedResult_storesResponseAndCopiesBody() throws Exception {
+    void When_ExecutedResult_Expect_StoresResponseAndCopiesBody() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "test-key");
 
@@ -117,7 +117,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void annotationTtlOverride_passesCustomTtlToStore() throws Exception {
+    void When_AnnotationTtlOverride_Expect_CustomTtlPassedToStore() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true, "PT2H", ""));
         request.addHeader("Idempotency-Key", "test-key");
 
@@ -135,7 +135,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void duplicateResult_replaysStoredResponse() throws Exception {
+    void When_DuplicateResult_Expect_StoredResponseReplayed() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "test-key");
         StoredResponse stored = storedResponse();
@@ -148,7 +148,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void duplicateResult_setsReplayedHeader() throws Exception {
+    void When_DuplicateResult_Expect_ReplayedHeaderSet() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "test-key");
         when(engine.execute(any(), any())).thenReturn(ExecutionResult.duplicate(storedResponse()));
@@ -159,7 +159,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void lockTimeoutException_returns503() throws Exception {
+    void When_LockTimeoutException_Expect_Returns503() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "test-key");
         when(engine.execute(any(), any()))
@@ -174,7 +174,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void actionThrows_releaseIsCalledByEngine() throws Exception {
+    void When_ActionThrows_Expect_ReleaseCalledByEngine() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "test-key");
         RuntimeException actionException = new RuntimeException("action failed");
@@ -187,7 +187,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void executedResult_storeCompleteThrows_bodyStillWritten() throws Exception {
+    void When_StoreCompleteThrows_Expect_BodyStillWritten() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "test-key");
 
@@ -218,7 +218,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void executedResult_storeCompleteThrows_retryBeforeLockExpiry_receives503() throws Exception {
+    void When_StoreCompleteThrowsAndRetryBeforeLockExpiry_Expect_Returns503() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "test-key");
 
@@ -258,7 +258,7 @@ class IdempotencyFilterTest {
     }
 
     @Test
-    void keyTooLong_returns422() throws Exception {
+    void When_KeyTooLong_Expect_Returns422() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "k".repeat(256));
 

--- a/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotentHandlerRegistryTest.java
+++ b/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotentHandlerRegistryTest.java
@@ -27,7 +27,7 @@ class IdempotentHandlerRegistryTest {
     }
 
     @Test
-    void invalidTtl_throwsIllegalStateException() {
+    void When_InvalidTtl_Expect_ThrowsIllegalStateException() {
         setupHandler(AnnotationHelper.annotation(true, "2h", ""));
 
         assertThatThrownBy(() -> registry.afterSingletonsInstantiated())
@@ -37,7 +37,7 @@ class IdempotentHandlerRegistryTest {
     }
 
     @Test
-    void invalidLockTimeout_throwsIllegalStateException() {
+    void When_InvalidLockTimeout_Expect_ThrowsIllegalStateException() {
         setupHandler(AnnotationHelper.annotation(true, "", "10s"));
 
         assertThatThrownBy(() -> registry.afterSingletonsInstantiated())
@@ -47,7 +47,7 @@ class IdempotentHandlerRegistryTest {
     }
 
     @Test
-    void validAnnotation_resolvesCorrectDurations() {
+    void When_ValidAnnotation_Expect_ResolvesCorrectDurations() {
         HandlerMethod handlerMethod = setupHandler(AnnotationHelper.annotation(true, "PT2H", "PT30S"));
         registry.afterSingletonsInstantiated();
 
@@ -59,7 +59,7 @@ class IdempotentHandlerRegistryTest {
     }
 
     @Test
-    void emptyDurations_fallBackToConfigDefaults() {
+    void When_EmptyDurations_Expect_FallBackToConfigDefaults() {
         HandlerMethod handlerMethod = setupHandler(AnnotationHelper.annotation(true, "", ""));
         registry.afterSingletonsInstantiated();
 
@@ -71,7 +71,7 @@ class IdempotentHandlerRegistryTest {
     }
 
     @Test
-    void nonAnnotatedHandler_notRegistered() {
+    void When_NonAnnotatedHandler_Expect_NotRegistered() {
         HandlerMethod handlerMethod = mock(HandlerMethod.class);
         when(handlerMethod.getMethodAnnotation(Idempotent.class)).thenReturn(null);
         when(handlerMapping.getHandlerMethods()).thenReturn(Map.of(mock(RequestMappingInfo.class), handlerMethod));


### PR DESCRIPTION
## Summary

Adds `IdempotencyPurgeAutoConfiguration` — a dedicated autoconfiguration class that registers a `SchedulingConfigurer` bean responsible for periodically purging expired idempotency records.

## Why `SchedulingConfigurer` instead of `@Scheduled`

`SchedulingConfigurer` is the correct mechanism for libraries. It participates in the application's scheduling infrastructure only if `@EnableScheduling` is already active in the application. If not, the bean is **completely inert** — it does not force scheduling behaviour onto the application context.

## Changes

### `IdempotencyProperties`
Added nested `Purge` static class binding to `idempotency.purge.*`:
- `enabled` (default `true`) — set to `false` to skip autoconfiguration entirely
- `cron` (default `"0 0 * * * *"`) — any valid Spring cron expression (hourly by default)

### `IdempotencyPurgeAutoConfiguration` (new)
- `@AutoConfiguration(after = IdempotencyAutoConfiguration.class)`
- `@ConditionalOnBean(IdempotencyStore.class)` — skipped if no store is present
- `@ConditionalOnProperty(prefix="idempotency.purge", name="enabled", havingValue="true", matchIfMissing=true)` — active by default
- `@EnableConfigurationProperties(IdempotencyProperties.class)` — works independently in non-web contexts
- Registers a `SchedulingConfigurer` bean that adds a cron task calling `IdempotencyStore.purgeExpired()`
- Validates the cron expression at bean creation time — throws `IllegalArgumentException` with the offending value if invalid
- Runtime `purgeExpired()` failures are caught and logged at `ERROR`; a single failure is non-fatal

### `AutoConfiguration.imports`
Registered `IdempotencyPurgeAutoConfiguration` alongside `IdempotencyAutoConfiguration`.

## Behaviour contract

| Condition | Result |
|-----------|--------|
| Purge enabled + `@EnableScheduling` active | Purge runs on configured cron |
| Purge enabled + no `@EnableScheduling` | Bean exists, completely inert |
| `idempotency.purge.enabled=false` | Autoconfiguration skipped, no bean created |
| No `IdempotencyStore` bean | Autoconfiguration skipped, no bean created |
| Invalid cron string | `IllegalArgumentException` at context startup with the bad value |
| `purgeExpired()` throws at runtime | Caught, logged at ERROR, task continues |

## Configuration

```yaml
idempotency:
  purge:
    enabled: true        # default
    cron: "0 0 * * * *" # default hourly
```

## Tests

6 new tests in `IdempotencyPurgeAutoConfigurationTest` (all passing):
1. Store bean present → purge configurer created by default
2. `purge.enabled=false` → purge configurer not created
3. No store bean → purge configurer not created
4. Custom valid cron → bean created, cron applied
5. Invalid cron → context startup fails with `IllegalArgumentException` containing the bad value
6. `purgeExpired()` throws → exception is swallowed, task continues

**Full suite: 16 tests, 0 failures.**