### PR TITLE
fix: issue cleanup — fix 6 findings, close 4 as not applicable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,20 @@ Push with `git push -u origin <branch>` and create the PR with `gh pr create`.
 When you change any code, make sure to analyze if this document needs any changing and apply the changes.
 This includes the explanations and the current implementation status.
 
+## Security considerations
+
+The idempotency store persists full HTTP response bodies and headers.
+This may include sensitive data such as PII, authentication tokens,
+or financial information.
+
+For compliance-sensitive environments:
+- Enable encryption at rest on the backing database
+- Use short TTL values to limit the retention window of cached responses
+- Consider the scheduled purge feature (`idempotency.purge.cron`) to
+  remove expired entries promptly
+- Audit which endpoints are annotated with `@Idempotent` and whether
+  their responses contain sensitive data
+
 ## Current implementation status
 
 ### Complete

--- a/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyConfigTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyConfigTest.java
@@ -3,6 +3,7 @@ package io.github.josipmusa.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 class IdempotencyConfigTest {
@@ -24,5 +25,38 @@ class IdempotencyConfigTest {
         assertThatThrownBy(() -> IdempotencyConfig.builder().keyHeader("  ").build())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("keyHeader must not be blank");
+    }
+
+    @Test
+    void When_NullKeyHeaderProvided_Expect_ThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> IdempotencyConfig.builder().keyHeader(null).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("keyHeader must not be blank");
+    }
+
+    @Test
+    void When_ZeroTtl_Expect_ThrowsIllegalArgumentException() {
+        assertThatThrownBy(() ->
+                        IdempotencyConfig.builder().defaultTtl(Duration.ZERO).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("defaultTtl must be positive");
+    }
+
+    @Test
+    void When_NegativeTtl_Expect_ThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> IdempotencyConfig.builder()
+                        .defaultTtl(Duration.ofSeconds(-1))
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("defaultTtl must be positive");
+    }
+
+    @Test
+    void When_LockTimeoutBelowMinimum_Expect_ThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> IdempotencyConfig.builder()
+                        .defaultLockTimeout(Duration.ofMillis(1))
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("defaultLockTimeout must be at least 2ms");
     }
 }

--- a/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyEngineTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyEngineTest.java
@@ -246,4 +246,17 @@ class IdempotencyEngineTest {
         // Heartbeat should never have started
         verify(store, never()).extendLock(any(), any());
     }
+
+    @Test
+    void When_HeartbeatExtendLockThrows_Expect_HeartbeatContinues() throws Exception {
+        IdempotencyContext context =
+                new IdempotencyContext("hb-error-key", Duration.ofHours(1), Duration.ofMillis(100));
+        when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
+        doThrow(new IdempotencyStoreException("connection lost")).when(store).extendLock(any(), any());
+
+        engine.execute(context, () -> Thread.sleep(300));
+
+        // Heartbeat should have been called multiple times despite throwing each time
+        verify(store, atLeast(2)).extendLock(eq("hb-error-key"), eq(Duration.ofMillis(100)));
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <testcontainers-mysql.version>1.20.4</testcontainers-mysql.version>
         <testcontainers-postgresql.version>1.20.4</testcontainers-postgresql.version>
         <testcontainers-junit-jupiter.version>1.20.4</testcontainers-junit-jupiter.version>
+        <jackson.version>2.18.2</jackson.version>
     </properties>
 
     <dependencyManagement>
@@ -74,6 +75,11 @@
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
                 <version>${jakarta.servlet-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>

--- a/providers/idempotency-inmemory/pom.xml
+++ b/providers/idempotency-inmemory/pom.xml
@@ -12,6 +12,7 @@
     </parent>
 
     <artifactId>idempotency-inmemory</artifactId>
+    <description>In-memory IdempotencyStore. Production usable for single-instance deployments and local development. Not suitable for horizontally scaled environments.</description>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/providers/idempotency-jdbc/pom.xml
+++ b/providers/idempotency-jdbc/pom.xml
@@ -26,6 +26,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStore.java
+++ b/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStore.java
@@ -1,5 +1,8 @@
 package io.github.josipmusa.idempotency.jdbc;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.josipmusa.core.AcquireResult;
 import io.github.josipmusa.core.IdempotencyContext;
 import io.github.josipmusa.core.IdempotencyStore;
@@ -19,8 +22,6 @@ import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -109,6 +110,8 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
     private final DataSource dataSource;
     private final long pollIntervalMs;
     private final Clock clock;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, List<String>>> HEADERS_TYPE = new TypeReference<>() {};
 
     public JdbcIdempotencyStore(DataSource dataSource) {
         this(dataSource, true);
@@ -467,153 +470,24 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
         }
     }
 
-    // --- JSON serialization (no external library) ---
+    // --- JSON serialization ---
 
     static String headersToJson(Map<String, List<String>> headers) {
-        StringBuilder sb = new StringBuilder();
-        sb.append('{');
-        boolean firstEntry = true;
-        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
-            if (!firstEntry) {
-                sb.append(',');
-            }
-            firstEntry = false;
-            sb.append('"');
-            escapeJson(sb, entry.getKey());
-            sb.append("\":[");
-            boolean firstVal = true;
-            for (String val : entry.getValue()) {
-                if (!firstVal) {
-                    sb.append(',');
-                }
-                firstVal = false;
-                sb.append('"');
-                escapeJson(sb, val);
-                sb.append('"');
-            }
-            sb.append(']');
+        try {
+            return OBJECT_MAPPER.writeValueAsString(headers);
+        } catch (JsonProcessingException e) {
+            throw new IdempotencyStoreException("Failed to serialize response headers to JSON", e);
         }
-        sb.append('}');
-        return sb.toString();
     }
 
     static Map<String, List<String>> jsonToHeaders(String json) {
-        Map<String, List<String>> result = new LinkedHashMap<>();
         if (json == null || json.equals("{}")) {
-            return result;
+            return Map.of();
         }
-        // Strip outer braces
-        String inner = json.substring(1, json.length() - 1).trim();
-        if (inner.isEmpty()) {
-            return result;
+        try {
+            return OBJECT_MAPPER.readValue(json, HEADERS_TYPE);
+        } catch (JsonProcessingException e) {
+            throw new IdempotencyStoreException("Failed to deserialize response headers from JSON", e);
         }
-        int pos = 0;
-        while (pos < inner.length()) {
-            // Read key
-            pos = inner.indexOf('"', pos) + 1;
-            int keyEnd = findUnescapedQuote(inner, pos);
-            String key = unescapeJson(inner.substring(pos, keyEnd));
-            pos = keyEnd + 1;
-            // Skip ':'
-            pos = inner.indexOf(':', pos) + 1;
-            // Skip '['
-            pos = inner.indexOf('[', pos) + 1;
-            // Read values
-            List<String> values = new ArrayList<>();
-            while (pos < inner.length() && inner.charAt(pos) != ']') {
-                if (inner.charAt(pos) == ',') {
-                    pos++;
-                }
-                if (inner.charAt(pos) == '"') {
-                    pos++;
-                    int valEnd = findUnescapedQuote(inner, pos);
-                    values.add(unescapeJson(inner.substring(pos, valEnd)));
-                    pos = valEnd + 1;
-                }
-            }
-            pos++; // skip ']'
-            result.put(key, List.copyOf(values));
-            // Skip comma if present
-            if (pos < inner.length() && inner.charAt(pos) == ',') {
-                pos++;
-            }
-        }
-        return Map.copyOf(result);
-    }
-
-    private static void escapeJson(StringBuilder sb, String value) {
-        for (int i = 0; i < value.length(); i++) {
-            char c = value.charAt(i);
-            switch (c) {
-                case '"' -> sb.append("\\\"");
-                case '\\' -> sb.append("\\\\");
-                case '\n' -> sb.append("\\n");
-                case '\r' -> sb.append("\\r");
-                case '\t' -> sb.append("\\t");
-                default -> {
-                    if (c < 0x20) {
-                        sb.append(String.format("\\u%04x", (int) c));
-                    } else {
-                        sb.append(c);
-                    }
-                }
-            }
-        }
-    }
-
-    private static int findUnescapedQuote(String s, int from) {
-        for (int i = from; i < s.length(); i++) {
-            if (s.charAt(i) == '\\') {
-                i++; // skip escaped character
-            } else if (s.charAt(i) == '"') {
-                return i;
-            }
-        }
-        return s.length();
-    }
-
-    private static String unescapeJson(String s) {
-        StringBuilder sb = new StringBuilder(s.length());
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            if (c == '\\' && i + 1 < s.length()) {
-                char next = s.charAt(i + 1);
-                switch (next) {
-                    case '"' -> {
-                        sb.append('"');
-                        i++;
-                    }
-                    case '\\' -> {
-                        sb.append('\\');
-                        i++;
-                    }
-                    case 'n' -> {
-                        sb.append('\n');
-                        i++;
-                    }
-                    case 'r' -> {
-                        sb.append('\r');
-                        i++;
-                    }
-                    case 't' -> {
-                        sb.append('\t');
-                        i++;
-                    }
-                    case 'u' -> {
-                        if (i + 5 <= s.length()) {
-                            String hex = s.substring(i + 2, i + 6);
-                            sb.append((char) Integer.parseInt(hex, 16));
-                            i += 5;
-                        } else {
-                            sb.append(c);
-                        }
-                    }
-                    default -> sb.append(c);
-                }
-            } else {
-                sb.append(c);
-            }
-        }
-        return sb.toString();
     }
 }

--- a/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
+++ b/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
@@ -102,6 +102,29 @@ class IdempotencyFilterTest {
     }
 
     @Test
+    void When_BlankKeyAndRequired_Expect_Returns422() throws Exception {
+        setupAnnotatedHandler(AnnotationHelper.annotation(true));
+        request.addHeader("Idempotency-Key", "   ");
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(422);
+        assertThat(response.getContentAsString()).isEqualTo("{\"error\": \"Idempotency-Key header is required\"}");
+        verifyNoInteractions(engine);
+    }
+
+    @Test
+    void When_BlankKeyAndNotRequired_Expect_ProceedsNormally() throws Exception {
+        setupAnnotatedHandler(AnnotationHelper.annotation(false));
+        request.addHeader("Idempotency-Key", "   ");
+
+        filter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verifyNoInteractions(engine);
+    }
+
+    @Test
     void When_ExecutedResult_Expect_StoresResponseAndCopiesBody() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "test-key");


### PR DESCRIPTION
## Summary

Addresses 10 code review findings from the issue tracker.

### Fixed (6 issues)

- **#13** — Added missing `<description>` to inmemory `pom.xml`, aligned with CLAUDE.md documentation
- **#14** — Replaced hand-rolled JSON parser in `JdbcIdempotencyStore` with Jackson `ObjectMapper`
- **#15** — Added security considerations section to CLAUDE.md documenting sensitive data storage risks
- **#18** — Added validation edge case tests to `IdempotencyConfigTest` (zero/negative TTL, lockTimeout < 2ms, null keyHeader)
- **#20** — Added tests for blank/whitespace-only idempotency key header
- **#21** — Added test verifying heartbeat continues after `store.extendLock()` throws

### Closed as not applicable (4 issues)

- **#19** — Heartbeat tests already use mocks; Clock injection is for stores, not the engine scheduler
- **#22** — InMemory module is intentionally thin; no eviction behavior exists to test
- **#23** — Entry is a private inner record; sealed interface would overengineer an internal detail
- **#25** — STEAL_LOCK returns `keepPolling()` by design; the caller retries — this is not a silent fail

### Verification

All 155 tests pass (`mvn verify` — BUILD SUCCESS).

Closes #13
Closes #14
Closes #15
Closes #18
Closes #20
Closes #21