### PR TITLE
Add request fingerprinting (SHA-256 body hash)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,10 @@ Fully resolved at construction. No optionals, no nulls.
 Built by the adapter using `IdempotencyConfig` defaults +
 annotation/request values before being passed to the engine.
 
+Fields: `key`, `ttl`, `lockTimeout`, `requestFingerprint`.
+The `requestFingerprint` is a SHA-256 hex digest of the request body,
+computed by the adapter layer (`RequestFingerprint.of(body)`).
+
 ### `IdempotencyConfig`
 
 Holds defaults (ttl, lockTimeout, keyHeader, keyRequired).
@@ -139,6 +143,9 @@ module, stop. The design is wrong.
 
 COMPLETE keys return `Duplicate` on subsequent `tryAcquire` calls
 until TTL expires, after which they are treated as new.
+
+COMPLETE keys return `FingerprintMismatch` when the incoming request
+fingerprint differs from the one stored with the original request.
 
 IN_PROGRESS keys whose `lockExpiresAt` is in the past are considered
 stale and can be stolen by the next `tryAcquire` caller.
@@ -253,6 +260,20 @@ Push with `git push -u origin <branch>` and create the PR with `gh pr create`.
 ## Instruction updating
 When you change any code, make sure to analyze if this document needs any changing and apply the changes.
 This includes the explanations and the current implementation status.
+
+## Request fingerprinting
+
+Every request's body is hashed (SHA-256) and stored alongside the
+idempotency key. When a subsequent request arrives with the same key
+but a different body hash, the store returns `FingerprintMismatch`
+instead of `Duplicate`, and the adapter returns HTTP 422.
+
+- **Computed in:** `RequestFingerprint.of(byte[] body)` in `idempotency-spring`
+- **Stored in:** `request_fingerprint VARCHAR(64)` column (JDBC) or
+  `requestFingerprint` field on `Entry` record (in-memory)
+- **Compared at:** store level in `tryAcquire()` when status is COMPLETE
+- **Engine mapping:** `FingerprintMismatch` → `IdempotencyFingerprintMismatchException`
+- **HTTP response:** 422 with `{"error": "Idempotency-Key reused with a different request body"}`
 
 ## Security considerations
 

--- a/idempotency-core/src/main/java/io/github/josipmusa/core/AcquireResult.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/AcquireResult.java
@@ -10,11 +10,15 @@ package io.github.josipmusa.core;
  *     case AcquireResult.Acquired a   -> // run the action
  *     case AcquireResult.Duplicate d  -> // replay d.response()
  *     case AcquireResult.LockTimeout t -> // timeout, reject request
+ *     case AcquireResult.FingerprintMismatch fm -> // reject: key reused with different body
  * }
  * }</pre>
  */
 public sealed interface AcquireResult
-        permits AcquireResult.Acquired, AcquireResult.Duplicate, AcquireResult.LockTimeout {
+        permits AcquireResult.Acquired,
+                AcquireResult.Duplicate,
+                AcquireResult.LockTimeout,
+                AcquireResult.FingerprintMismatch {
 
     /**
      * Lock obtained — this caller owns the key and should execute the action.
@@ -36,6 +40,13 @@ public sealed interface AcquireResult
      */
     record LockTimeout(String key) implements AcquireResult {}
 
+    /**
+     * Key was already completed but the request fingerprint does not match
+     * the one stored with the original request. The caller should return
+     * HTTP 422 to indicate the key was reused with a different payload.
+     */
+    record FingerprintMismatch(String storedFingerprint, String receivedFingerprint) implements AcquireResult {}
+
     static AcquireResult acquired() {
         return new Acquired();
     }
@@ -46,5 +57,9 @@ public sealed interface AcquireResult
 
     static AcquireResult lockTimeout(String key) {
         return new LockTimeout(key);
+    }
+
+    static AcquireResult fingerprintMismatch(String storedFingerprint, String receivedFingerprint) {
+        return new FingerprintMismatch(storedFingerprint, receivedFingerprint);
     }
 }

--- a/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyContext.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyContext.java
@@ -25,8 +25,11 @@ import java.util.Objects;
  *                    initial lock expiration — if the holder crashes without
  *                    completing or releasing, the lock becomes stealable
  *                    after this duration.
+ * @param requestFingerprint a hash of the request body (e.g. SHA-256 hex).
+ *                           Used to detect when the same idempotency key is
+ *                           reused with a different request payload.
  */
-public record IdempotencyContext(String key, Duration ttl, Duration lockTimeout) {
+public record IdempotencyContext(String key, Duration ttl, Duration lockTimeout, String requestFingerprint) {
 
     private static final Duration MIN_LOCK_TIMEOUT = Duration.ofMillis(2);
     private static final int MAX_KEY_LENGTH = 255;
@@ -47,6 +50,10 @@ public record IdempotencyContext(String key, Duration ttl, Duration lockTimeout)
         }
         if (lockTimeout.compareTo(MIN_LOCK_TIMEOUT) < 0) {
             throw new IllegalArgumentException("lockTimeout must be at least 2ms");
+        }
+        Objects.requireNonNull(requestFingerprint, "requestFingerprint must not be null");
+        if (requestFingerprint.isBlank()) {
+            throw new IllegalArgumentException("requestFingerprint must not be blank");
         }
     }
 }

--- a/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyEngine.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyEngine.java
@@ -1,5 +1,6 @@
 package io.github.josipmusa.core;
 
+import io.github.josipmusa.core.exception.IdempotencyFingerprintMismatchException;
 import io.github.josipmusa.core.exception.IdempotencyLockTimeoutException;
 import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
@@ -87,6 +88,8 @@ public final class IdempotencyEngine {
             case AcquireResult.Duplicate d -> ExecutionResult.duplicate(d.response());
             case AcquireResult.LockTimeout ignored -> throw new IdempotencyLockTimeoutException(
                     context.key(), context.lockTimeout());
+            case AcquireResult.FingerprintMismatch fm -> throw new IdempotencyFingerprintMismatchException(
+                    context.key(), fm.storedFingerprint(), fm.receivedFingerprint());
         };
     }
 

--- a/idempotency-core/src/main/java/io/github/josipmusa/core/exception/IdempotencyFingerprintMismatchException.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/exception/IdempotencyFingerprintMismatchException.java
@@ -1,0 +1,40 @@
+package io.github.josipmusa.core.exception;
+
+import java.io.Serial;
+
+/**
+ * Thrown by the engine when a duplicate request is detected but the request
+ * body fingerprint does not match the one stored with the original request.
+ *
+ * <p>This indicates the client reused an idempotency key with a different
+ * payload. The adapter should return HTTP 422 Unprocessable Entity.
+ */
+public class IdempotencyFingerprintMismatchException extends IdempotencyException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final String key;
+    private final String storedFingerprint;
+    private final String receivedFingerprint;
+
+    public IdempotencyFingerprintMismatchException(String key, String storedFingerprint, String receivedFingerprint) {
+        super("Request fingerprint mismatch for key '" + key + "': stored=" + storedFingerprint + ", received="
+                + receivedFingerprint);
+        this.key = key;
+        this.storedFingerprint = storedFingerprint;
+        this.receivedFingerprint = receivedFingerprint;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getStoredFingerprint() {
+        return storedFingerprint;
+    }
+
+    public String getReceivedFingerprint() {
+        return receivedFingerprint;
+    }
+}

--- a/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyEngineTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyEngineTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import io.github.josipmusa.core.exception.IdempotencyFingerprintMismatchException;
 import io.github.josipmusa.core.exception.IdempotencyLockTimeoutException;
 import io.github.josipmusa.core.exception.IdempotencyStoreException;
 import java.io.IOException;
@@ -39,7 +40,7 @@ class IdempotencyEngineTest {
     }
 
     private IdempotencyContext defaultContext(String key) {
-        return new IdempotencyContext(key, Duration.ofHours(1), Duration.ofSeconds(5));
+        return new IdempotencyContext(key, Duration.ofHours(1), Duration.ofSeconds(5), "test-fingerprint");
     }
 
     private StoredResponse anyStoredResponse() {
@@ -132,7 +133,8 @@ class IdempotencyEngineTest {
 
     @Test
     void When_LongRunningAction_Expect_HeartbeatExtendsLock() throws Exception {
-        IdempotencyContext context = new IdempotencyContext("hb-key", Duration.ofHours(1), Duration.ofMillis(100));
+        IdempotencyContext context =
+                new IdempotencyContext("hb-key", Duration.ofHours(1), Duration.ofMillis(100), "test-fingerprint");
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
         engine.execute(context, () -> Thread.sleep(300));
@@ -142,7 +144,8 @@ class IdempotencyEngineTest {
 
     @Test
     void When_ActionCompletes_Expect_HeartbeatStops() throws Exception {
-        IdempotencyContext context = new IdempotencyContext("hb-stop-key", Duration.ofHours(1), Duration.ofMillis(100));
+        IdempotencyContext context =
+                new IdempotencyContext("hb-stop-key", Duration.ofHours(1), Duration.ofMillis(100), "test-fingerprint");
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
         engine.execute(context, () -> {});
@@ -167,7 +170,7 @@ class IdempotencyEngineTest {
     @Test
     void When_ActionThrows_Expect_HeartbeatStops() throws Exception {
         IdempotencyContext context =
-                new IdempotencyContext("hb-throw-key", Duration.ofHours(1), Duration.ofMillis(100));
+                new IdempotencyContext("hb-throw-key", Duration.ofHours(1), Duration.ofMillis(100), "test-fingerprint");
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
         try {
@@ -190,6 +193,18 @@ class IdempotencyEngineTest {
                 .size();
 
         assertThat(countAfterWait).isEqualTo(countAfterExecute);
+    }
+
+    @Test
+    void When_FingerprintMismatch_Expect_ThrowsFingerprintMismatchException() throws Exception {
+        IdempotencyContext context = defaultContext("fp-mismatch-key");
+        when(store.tryAcquire(context)).thenReturn(AcquireResult.fingerprintMismatch("stored-hash", "received-hash"));
+
+        assertThatThrownBy(() -> engine.execute(context, () -> {}))
+                .isInstanceOf(IdempotencyFingerprintMismatchException.class)
+                .hasMessageContaining("fp-mismatch-key")
+                .hasMessageContaining("stored-hash")
+                .hasMessageContaining("received-hash");
     }
 
     // --- Context forwarding ---
@@ -250,7 +265,7 @@ class IdempotencyEngineTest {
     @Test
     void When_HeartbeatExtendLockThrows_Expect_HeartbeatContinues() throws Exception {
         IdempotencyContext context =
-                new IdempotencyContext("hb-error-key", Duration.ofHours(1), Duration.ofMillis(100));
+                new IdempotencyContext("hb-error-key", Duration.ofHours(1), Duration.ofMillis(100), "test-fingerprint");
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
         doThrow(new IdempotencyStoreException("connection lost")).when(store).extendLock(any(), any());
 

--- a/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
+++ b/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
@@ -27,15 +27,19 @@ public abstract class IdempotencyStoreContract {
     protected abstract IdempotencyStore store();
 
     protected IdempotencyContext contextFor(String key) {
-        return new IdempotencyContext(key, Duration.ofHours(1), Duration.ofSeconds(5));
+        return new IdempotencyContext(key, Duration.ofHours(1), Duration.ofSeconds(5), "default-fingerprint");
     }
 
     protected IdempotencyContext contextFor(String key, Duration lockTimeout) {
-        return new IdempotencyContext(key, Duration.ofHours(1), lockTimeout);
+        return new IdempotencyContext(key, Duration.ofHours(1), lockTimeout, "default-fingerprint");
     }
 
     private IdempotencyContext contextFor(String key, Duration ttl, Duration lockTimeout) {
-        return new IdempotencyContext(key, ttl, lockTimeout);
+        return new IdempotencyContext(key, ttl, lockTimeout, "default-fingerprint");
+    }
+
+    protected IdempotencyContext contextFor(String key, String fingerprint) {
+        return new IdempotencyContext(key, Duration.ofHours(1), Duration.ofSeconds(5), fingerprint);
     }
 
     private StoredResponse sampleResponse() {
@@ -610,5 +614,48 @@ public abstract class IdempotencyStoreContract {
         s.tryAcquire(ctx);
         int removed = s.purgeExpired();
         assertThat(removed).isEqualTo(0);
+    }
+
+    // ── Fingerprint tests ──────────────────────────────────────────────
+
+    @Test
+    void When_SameKeyAndSameFingerprint_Expect_Duplicate() {
+        IdempotencyStore s = store();
+        var context = contextFor("fp-same", "sha256-abc123");
+        s.tryAcquire(context);
+        s.complete("fp-same", sampleResponse(), Duration.ofHours(1));
+
+        var result = s.tryAcquire(context);
+
+        assertThat(result).isInstanceOf(AcquireResult.Duplicate.class);
+    }
+
+    @Test
+    void When_SameKeyButDifferentFingerprint_Expect_FingerprintMismatch() {
+        IdempotencyStore s = store();
+        var original = contextFor("fp-diff", "sha256-original");
+        s.tryAcquire(original);
+        s.complete("fp-diff", sampleResponse(), Duration.ofHours(1));
+
+        var reused = contextFor("fp-diff", "sha256-different");
+        var result = s.tryAcquire(reused);
+
+        assertThat(result).isInstanceOf(AcquireResult.FingerprintMismatch.class);
+        var mismatch = (AcquireResult.FingerprintMismatch) result;
+        assertThat(mismatch.storedFingerprint()).isEqualTo("sha256-original");
+        assertThat(mismatch.receivedFingerprint()).isEqualTo("sha256-different");
+    }
+
+    @Test
+    void When_KeyReleasedAndReAcquiredWithDifferentFingerprint_Expect_Acquired() {
+        IdempotencyStore s = store();
+        var first = contextFor("fp-reacquire", "sha256-first");
+        s.tryAcquire(first);
+        s.release("fp-reacquire");
+
+        var second = contextFor("fp-reacquire", "sha256-second");
+        var result = s.tryAcquire(second);
+
+        assertThat(result).isInstanceOf(AcquireResult.Acquired.class);
     }
 }

--- a/providers/idempotency-inmemory/src/main/java/io/github/josipmusa/idempotency/inmemory/InMemoryIdempotencyStore.java
+++ b/providers/idempotency-inmemory/src/main/java/io/github/josipmusa/idempotency/inmemory/InMemoryIdempotencyStore.java
@@ -40,7 +40,12 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
      * {@code lockTimeout} is {@code null} for COMPLETE entries where it is not needed.
      */
     private record Entry(
-            Status status, StoredResponse response, Instant lockExpiresAt, Instant expiresAt, Duration lockTimeout) {}
+            Status status,
+            StoredResponse response,
+            Instant lockExpiresAt,
+            Instant expiresAt,
+            Duration lockTimeout,
+            String requestFingerprint) {}
 
     private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>();
     private final Clock clock;
@@ -85,7 +90,8 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
                     null,
                     now.plus(context.lockTimeout()),
                     now.plus(context.ttl()),
-                    context.lockTimeout());
+                    context.lockTimeout(),
+                    context.requestFingerprint());
 
             Entry existing = store.putIfAbsent(context.key(), newEntry);
 
@@ -94,6 +100,10 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
             }
 
             if (existing.status() == Status.COMPLETE) {
+                if (!existing.requestFingerprint().equals(context.requestFingerprint())) {
+                    return AcquireResult.fingerprintMismatch(
+                            existing.requestFingerprint(), context.requestFingerprint());
+                }
                 return AcquireResult.duplicate(existing.response());
             }
 
@@ -137,7 +147,8 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
                 throw new IdempotencyStoreException(
                         "Cannot complete key '" + key + "': entry is " + existing.status() + ", expected IN_PROGRESS");
             }
-            return new Entry(Status.COMPLETE, response, null, clock.instant().plus(ttl), null);
+            return new Entry(
+                    Status.COMPLETE, response, null, clock.instant().plus(ttl), null, existing.requestFingerprint());
         });
     }
 
@@ -155,7 +166,8 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
             // Expire after lockTimeout rather than full TTL — FAILED entries are immediately
             // re-acquirable, so keeping them for the full TTL would unnecessarily retain memory.
             Instant failedExpiry = clock.instant().plus(existing.lockTimeout());
-            return new Entry(Status.FAILED, null, null, failedExpiry, existing.lockTimeout());
+            return new Entry(
+                    Status.FAILED, null, null, failedExpiry, existing.lockTimeout(), existing.requestFingerprint());
         });
     }
 
@@ -166,7 +178,12 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
                 return entry;
             }
             return new Entry(
-                    Status.IN_PROGRESS, null, clock.instant().plus(extension), entry.expiresAt(), entry.lockTimeout());
+                    Status.IN_PROGRESS,
+                    null,
+                    clock.instant().plus(extension),
+                    entry.expiresAt(),
+                    entry.lockTimeout(),
+                    entry.requestFingerprint());
         });
     }
 

--- a/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStore.java
+++ b/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStore.java
@@ -52,17 +52,18 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
             "DELETE FROM idempotency_records WHERE idempotency_key = ? AND expires_at < ? AND status = 'COMPLETE'";
 
     private static final String INSERT =
-            "INSERT INTO idempotency_records (idempotency_key, status, locked_at, lock_expires_at, expires_at) "
-                    + "VALUES (?, 'IN_PROGRESS', ?, ?, ?)";
+            "INSERT INTO idempotency_records (idempotency_key, status, locked_at, lock_expires_at, expires_at, request_fingerprint) "
+                    + "VALUES (?, 'IN_PROGRESS', ?, ?, ?, ?)";
 
     private static final String SELECT_FOR_UPDATE =
-            "SELECT status, lock_expires_at, response_code, response_headers, response_body, completed_at "
+            "SELECT status, lock_expires_at, response_code, response_headers, response_body, completed_at, request_fingerprint "
                     + "FROM idempotency_records WHERE idempotency_key = ? FOR UPDATE";
 
     private static final String SELECT_STATUS = "SELECT status FROM idempotency_records WHERE idempotency_key = ?";
 
     private static final String STEAL_LOCK =
             "UPDATE idempotency_records SET status = 'IN_PROGRESS', locked_at = ?, lock_expires_at = ?, "
+                    + "request_fingerprint = ?, "
                     + "response_code = NULL, response_headers = NULL, response_body = NULL, completed_at = NULL "
                     + "WHERE idempotency_key = ? AND (status = 'FAILED' OR (status = 'IN_PROGRESS' AND lock_expires_at < ?))";
 
@@ -338,6 +339,7 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
                 ins.setTimestamp(2, Timestamp.from(now));
                 ins.setTimestamp(3, Timestamp.from(now.plus(context.lockTimeout())));
                 ins.setTimestamp(4, Timestamp.from(now.plus(context.ttl())));
+                ins.setString(5, context.requestFingerprint());
                 ins.executeUpdate();
                 return true;
             } catch (SQLException e) {
@@ -385,6 +387,11 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
                 Timestamp lockExpiresTs = rs.getTimestamp("lock_expires_at");
 
                 if ("COMPLETE".equals(status)) {
+                    String storedFingerprint = rs.getString("request_fingerprint");
+                    if (storedFingerprint != null && !storedFingerprint.equals(context.requestFingerprint())) {
+                        return RowInspection.resolved(
+                                AcquireResult.fingerprintMismatch(storedFingerprint, context.requestFingerprint()));
+                    }
                     return RowInspection.resolved(AcquireResult.duplicate(readResponse(rs)));
                 }
 
@@ -403,8 +410,9 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
         try (PreparedStatement ps = conn.prepareStatement(STEAL_LOCK)) {
             ps.setTimestamp(1, Timestamp.from(now));
             ps.setTimestamp(2, Timestamp.from(now.plus(context.lockTimeout())));
-            ps.setString(3, context.key());
-            ps.setTimestamp(4, Timestamp.from(now));
+            ps.setString(3, context.requestFingerprint());
+            ps.setString(4, context.key());
+            ps.setTimestamp(5, Timestamp.from(now));
             return ps.executeUpdate() > 0;
         }
     }

--- a/providers/idempotency-jdbc/src/main/resources/idempotency-schema-mysql.sql
+++ b/providers/idempotency-jdbc/src/main/resources/idempotency-schema-mysql.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS idempotency_records (
     response_code     INT           NULL,
     response_headers  TEXT          NULL,
     response_body     BLOB          NULL,
+    request_fingerprint VARCHAR(64) NULL,
     completed_at      TIMESTAMP(6)  NULL,
     created_at        TIMESTAMP(6)  DEFAULT CURRENT_TIMESTAMP(6) NOT NULL,
     expires_at        TIMESTAMP(6)  NULL,

--- a/providers/idempotency-jdbc/src/main/resources/idempotency-schema-postgresql.sql
+++ b/providers/idempotency-jdbc/src/main/resources/idempotency-schema-postgresql.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS idempotency_records (
     response_code     INT           NULL,
     response_headers  TEXT          NULL,
     response_body     BYTEA         NULL,
+    request_fingerprint VARCHAR(64) NULL,
     completed_at      TIMESTAMP(6)  NULL,
     created_at        TIMESTAMP(6)  DEFAULT CURRENT_TIMESTAMP NOT NULL,
     expires_at        TIMESTAMP(6)  NULL,

--- a/providers/idempotency-jdbc/src/test/java/io/github/josipmusa/idempotency/jdbc/MysqlJdbcIdempotencyStoreTest.java
+++ b/providers/idempotency-jdbc/src/test/java/io/github/josipmusa/idempotency/jdbc/MysqlJdbcIdempotencyStoreTest.java
@@ -68,7 +68,8 @@ class MysqlJdbcIdempotencyStoreTest extends IdempotencyStoreContract {
         when(exhaustedDs.getConnection()).thenThrow(new SQLException("connection pool exhausted", "08001"));
 
         JdbcIdempotencyStore failingStore = new JdbcIdempotencyStore(exhaustedDs, false);
-        IdempotencyContext context = new IdempotencyContext("key", Duration.ofHours(1), Duration.ofSeconds(5));
+        IdempotencyContext context =
+                new IdempotencyContext("key", Duration.ofHours(1), Duration.ofSeconds(5), "test-fingerprint");
 
         assertThatThrownBy(() -> failingStore.tryAcquire(context)).isInstanceOf(IdempotencyStoreException.class);
     }

--- a/providers/idempotency-jdbc/src/test/java/io/github/josipmusa/idempotency/jdbc/PostgresJdbcIdempotencyStoreTest.java
+++ b/providers/idempotency-jdbc/src/test/java/io/github/josipmusa/idempotency/jdbc/PostgresJdbcIdempotencyStoreTest.java
@@ -68,7 +68,8 @@ class PostgresJdbcIdempotencyStoreTest extends IdempotencyStoreContract {
         when(exhaustedDs.getConnection()).thenThrow(new SQLException("connection pool exhausted", "08001"));
 
         JdbcIdempotencyStore failingStore = new JdbcIdempotencyStore(exhaustedDs, false);
-        IdempotencyContext context = new IdempotencyContext("key", Duration.ofHours(1), Duration.ofSeconds(5));
+        IdempotencyContext context =
+                new IdempotencyContext("key", Duration.ofHours(1), Duration.ofSeconds(5), "test-fingerprint");
 
         assertThat(failingStore).isNotNull();
         org.assertj.core.api.Assertions.assertThatThrownBy(() -> failingStore.tryAcquire(context))

--- a/spring/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
+++ b/spring/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
@@ -8,6 +8,7 @@ import io.github.josipmusa.core.IdempotencyContext;
 import io.github.josipmusa.core.IdempotencyEngine;
 import io.github.josipmusa.core.IdempotencyStore;
 import io.github.josipmusa.core.StoredResponse;
+import io.github.josipmusa.core.exception.IdempotencyFingerprintMismatchException;
 import io.github.josipmusa.core.exception.IdempotencyLockTimeoutException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -28,6 +29,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 /**
@@ -47,6 +49,7 @@ public class IdempotencyFilter extends OncePerRequestFilter {
     private static final String ERROR_MISSING_KEY = "Idempotency-Key header is required";
     private static final String ERROR_KEY_TOO_LONG = "Idempotency-Key must not exceed 255 characters";
     private static final String ERROR_LOCK_TIMEOUT = "Request with this key is already being processed";
+    private static final String ERROR_FINGERPRINT_MISMATCH = "Idempotency-Key reused with a different request body";
 
     private final IdempotencyEngine engine;
     private final IdempotencyStore store;
@@ -93,9 +96,15 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             return;
         }
 
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+        // Force reading the body so ContentCachingRequestWrapper caches it
+        wrappedRequest.getInputStream().readAllBytes();
+        String fingerprint = RequestFingerprint.of(wrappedRequest.getContentAsByteArray());
+
         IdempotencyContext context;
         try {
-            context = new IdempotencyContext(key, resolvedIdempotent.ttl(), resolvedIdempotent.lockTimeout());
+            context = new IdempotencyContext(
+                    key, resolvedIdempotent.ttl(), resolvedIdempotent.lockTimeout(), fingerprint);
         } catch (IllegalArgumentException e) {
             writeJsonError(response, 422, ERROR_KEY_TOO_LONG);
             return;
@@ -104,7 +113,10 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
         ExecutionResult result;
         try {
-            result = engine.execute(context, () -> chain.doFilter(request, wrappedResponse));
+            result = engine.execute(context, () -> chain.doFilter(wrappedRequest, wrappedResponse));
+        } catch (IdempotencyFingerprintMismatchException e) {
+            writeJsonError(response, 422, ERROR_FINGERPRINT_MISMATCH);
+            return;
         } catch (IdempotencyLockTimeoutException e) {
             writeJsonError(response, HttpServletResponse.SC_SERVICE_UNAVAILABLE, ERROR_LOCK_TIMEOUT);
             return;

--- a/spring/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/RequestFingerprint.java
+++ b/spring/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/RequestFingerprint.java
@@ -1,0 +1,33 @@
+package io.github.josipmusa.idempotency.spring;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * Computes a SHA-256 hex digest of a request body. The resulting 64-character
+ * lowercase hex string is stored alongside the idempotency key so that reuse
+ * of the same key with a different payload can be detected.
+ */
+public final class RequestFingerprint {
+
+    private static final String ALGORITHM = "SHA-256";
+
+    private RequestFingerprint() {}
+
+    /**
+     * Compute SHA-256 hex of the given body bytes.
+     *
+     * @param body the raw request body; must not be null
+     * @return 64-character lowercase hex SHA-256 digest
+     */
+    public static String of(byte[] body) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(ALGORITHM);
+            byte[] hash = digest.digest(body);
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
+    }
+}

--- a/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
+++ b/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import io.github.josipmusa.core.*;
+import io.github.josipmusa.core.exception.IdempotencyFingerprintMismatchException;
 import io.github.josipmusa.core.exception.IdempotencyLockTimeoutException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletResponse;
@@ -320,6 +321,36 @@ class IdempotencyFilterTest {
         assertThat(response.getContentAsString())
                 .isEqualTo("{\"error\": \"Idempotency-Key must not exceed 255 characters\"}");
         verifyNoInteractions(engine);
+    }
+
+    @Test
+    void When_FingerprintMismatch_Expect_Returns422() throws Exception {
+        setupAnnotatedHandler(AnnotationHelper.annotation(true));
+        request.addHeader("Idempotency-Key", "key-1");
+        request.setContent("{\"amount\":100}".getBytes());
+        when(engine.execute(any(), any()))
+                .thenThrow(new IdempotencyFingerprintMismatchException("key-1", "stored-hash", "received-hash"));
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(422);
+        assertThat(response.getContentAsString()).contains("Idempotency-Key reused with a different request body");
+    }
+
+    @Test
+    void When_SameBodyResubmitted_Expect_Replayed() throws Exception {
+        setupAnnotatedHandler(AnnotationHelper.annotation(true));
+        request.addHeader("Idempotency-Key", "key-1");
+        request.setContent("{\"amount\":100}".getBytes());
+
+        StoredResponse storedResponse = new StoredResponse(
+                200, Map.of("Content-Type", List.of("application/json")), "{\"id\":\"123\"}".getBytes(), Instant.now());
+        when(engine.execute(any(), any())).thenReturn(ExecutionResult.duplicate(storedResponse));
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeader("Idempotent-Replayed")).isEqualTo("true");
     }
 
     private void setupAnnotatedHandler(Idempotent annotation) throws Exception {

--- a/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/RequestFingerprintTest.java
+++ b/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/RequestFingerprintTest.java
@@ -1,0 +1,34 @@
+package io.github.josipmusa.idempotency.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class RequestFingerprintTest {
+
+    @Test
+    void When_SameBody_Expect_SameHash() {
+        byte[] body = "{\"amount\":100}".getBytes(StandardCharsets.UTF_8);
+        String first = RequestFingerprint.of(body);
+        String second = RequestFingerprint.of(body);
+
+        assertThat(first).isEqualTo(second);
+        assertThat(first).hasSize(64);
+    }
+
+    @Test
+    void When_DifferentBody_Expect_DifferentHash() {
+        String hash1 = RequestFingerprint.of("{\"amount\":100}".getBytes(StandardCharsets.UTF_8));
+        String hash2 = RequestFingerprint.of("{\"amount\":200}".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(hash1).isNotEqualTo(hash2);
+    }
+
+    @Test
+    void When_EmptyBody_Expect_ValidHash() {
+        String hash = RequestFingerprint.of(new byte[0]);
+
+        assertThat(hash).hasSize(64);
+    }
+}


### PR DESCRIPTION
Detect when an idempotency key is reused with a different request payload by storing a SHA-256 hash of the request body alongside the key.

## Changes

**Core domain:**
- `IdempotencyContext`: new `requestFingerprint` field (validated non-null, non-blank)
- `AcquireResult`: new `FingerprintMismatch` sealed variant
- `IdempotencyFingerprintMismatchException`: new exception

**Engine:**
- Maps `FingerprintMismatch` result to exception throw

**Stores:**
- InMemory: stores fingerprint on `Entry` record, compares on COMPLETE
- JDBC: `request_fingerprint VARCHAR(64)` column, compared in `doInspectRow`
- MySQL + PostgreSQL schemas updated

**Adapter (Spring):**
- `RequestFingerprint` utility: SHA-256 hex of body bytes
- `IdempotencyFilter`: wraps request with `ContentCachingRequestWrapper`, computes fingerprint, catches mismatch → 422

**Tests:**
- 3 contract tests (same fingerprint, different fingerprint, re-acquire after release)
- Engine fingerprint mismatch test
- Filter mismatch + replay tests
- RequestFingerprint utility tests

**Docs:**
- CLAUDE.md updated with fingerprinting section

Closes #12