### PR TITLE
Add idempotency-bom and align Spring version management

### DIFF
--- a/idempotency-bom/pom.xml
+++ b/idempotency-bom/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.josipmusa</groupId>
+    <artifactId>idempotency-bom</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>idempotency-bom</name>
+    <description>Bill of Materials for idempotency4j. Import this in your dependencyManagement
+        section to get aligned versions of all idempotency4j modules.</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.josipmusa</groupId>
+                <artifactId>idempotency-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.josipmusa</groupId>
+                <artifactId>idempotency-inmemory</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.josipmusa</groupId>
+                <artifactId>idempotency-jdbc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.josipmusa</groupId>
+                <artifactId>idempotency-test</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.josipmusa</groupId>
+                <artifactId>idempotency-spring</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.josipmusa</groupId>
+                <artifactId>idempotency-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <description>Idempotency Java Library</description>
 
     <modules>
+        <module>idempotency-bom</module>
         <module>idempotency-core</module>
         <module>providers/idempotency-inmemory</module>
         <module>providers/idempotency-jdbc</module>
@@ -28,9 +29,7 @@
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.14.2</mockito.version>
-        <spring.version>6.2.3</spring.version>
         <spring-boot.version>3.5.6</spring-boot.version>
-        <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <testcontainers-mysql.version>1.20.4</testcontainers-mysql.version>
         <testcontainers-postgresql.version>1.20.4</testcontainers-postgresql.version>
         <testcontainers-junit-jupiter.version>1.20.4</testcontainers-junit-jupiter.version>
@@ -55,26 +54,11 @@
                 <version>${mockito.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-webmvc</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-test</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.servlet</groupId>
-                <artifactId>jakarta.servlet-api</artifactId>
-                <version>${jakarta.servlet-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Changes

### BOM artifact (#33)
Added `idempotency-bom` module — a Bill of Materials that consumers can import in their `<dependencyManagement>` section to get aligned versions of all idempotency4j modules:

```xml
<dependencyManagement>
    <dependencies>
        <dependency>
            <groupId>io.github.josipmusa</groupId>
            <artifactId>idempotency-bom</artifactId>
            <version>${idempotency4j.version}</version>
            <type>pom</type>
            <scope>import</scope>
        </dependency>
    </dependencies>
</dependencyManagement>
```

This is especially useful for users of `idempotency-spring` who don't use the Spring Boot starter — they can import the BOM and declare individual modules without worrying about version alignment.

### Spring version alignment (#34)
Removed the explicit `spring.version` and `jakarta.servlet-api.version` properties. Spring Framework and Servlet API versions are now managed solely by the Spring Boot BOM (`spring-boot-dependencies`), eliminating any risk of version drift.

Closes #33
Closes #34