### PR TITLE
Fix review findings: 9 bug-fixes and improvements

### DIFF
--- a/idempotency-bom/pom.xml
+++ b/idempotency-bom/pom.xml
@@ -4,9 +4,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.josipmusa</groupId>
+    <parent>
+        <groupId>io.github.josipmusa</groupId>
+        <artifactId>idempotency4j</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>idempotency-bom</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>idempotency-bom</name>

--- a/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyConfig.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyConfig.java
@@ -28,10 +28,21 @@ public final class IdempotencyConfig {
         this.keyHeader = builder.keyHeader;
     }
 
+    /**
+     * Returns a new builder with all defaults applied.
+     *
+     * @return a builder for constructing {@link IdempotencyConfig}
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Returns an {@link IdempotencyConfig} with all defaults: 24h TTL,
+     * 10s lock timeout, and {@code "Idempotency-Key"} header.
+     *
+     * @return a default config instance
+     */
     public static IdempotencyConfig defaults() {
         return builder().build();
     }
@@ -53,23 +64,73 @@ public final class IdempotencyConfig {
         private Duration defaultLockTimeout = Duration.ofSeconds(10);
         private String keyHeader = "Idempotency-Key";
 
+        /**
+         * Sets the default TTL for completed idempotency records.
+         *
+         * <p>After this duration the record expires and the key can be reused
+         * for a new request. Defaults to 24 hours.
+         *
+         * @param ttl must be positive (non-zero, non-negative)
+         * @return this builder
+         * @throws IllegalArgumentException if {@code ttl} is zero or negative
+         */
         public Builder defaultTtl(Duration ttl) {
             Objects.requireNonNull(ttl, "defaultTtl must not be null");
             this.defaultTtl = ttl;
             return this;
         }
 
+        /**
+         * Sets the default lock timeout for in-flight requests.
+         *
+         * <p>A second caller arriving while the key is IN_PROGRESS will block
+         * for up to this duration waiting for a result. If the holder does not
+         * complete within this window, the second caller receives
+         * {@link AcquireResult.LockTimeout}.
+         *
+         * <p>This value is also the initial lock expiry for the holder — if the
+         * holder crashes without completing or releasing, the lock becomes
+         * stealable after this duration. The heartbeat extends the lock at
+         * half this interval, so this value effectively sets the crash-detection
+         * window as well.
+         *
+         * <p>Defaults to 10 seconds. Minimum is 2 ms (the engine divides by 2
+         * for the heartbeat interval, so values below 2 ms are rejected).
+         *
+         * @param timeout must be at least 2 ms
+         * @return this builder
+         * @throws IllegalArgumentException if {@code timeout} is less than 2 ms
+         */
         public Builder defaultLockTimeout(Duration timeout) {
             Objects.requireNonNull(timeout, "defaultLockTimeout must not be null");
             this.defaultLockTimeout = timeout;
             return this;
         }
 
+        /**
+         * Sets the HTTP header name used to carry the idempotency key.
+         *
+         * <p>Defaults to {@code "Idempotency-Key"} per the IETF draft standard.
+         * Override if your API uses a different header convention
+         * (e.g. {@code "X-Idempotency-Key"}).
+         *
+         * @param keyHeader must not be null or blank
+         * @return this builder
+         * @throws IllegalArgumentException if {@code keyHeader} is blank
+         */
         public Builder keyHeader(String keyHeader) {
             this.keyHeader = keyHeader;
             return this;
         }
 
+        /**
+         * Constructs the {@link IdempotencyConfig} with the configured values.
+         *
+         * @return a new immutable config instance
+         * @throws IllegalArgumentException if any value fails validation
+         *         ({@code defaultTtl} must be positive; {@code defaultLockTimeout}
+         *         must be &ge; 2 ms; {@code keyHeader} must not be blank)
+         */
         public IdempotencyConfig build() {
             if (defaultTtl.isZero() || defaultTtl.isNegative()) {
                 throw new IllegalArgumentException("defaultTtl must be positive, got: " + defaultTtl);

--- a/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
+++ b/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
@@ -115,6 +115,25 @@ public abstract class IdempotencyStoreContract {
     }
 
     @Test
+    void When_StaleLockAndSameLockTimeout_Expect_IsStolen() throws InterruptedException {
+        IdempotencyStore s = store();
+        String key = "stale-same-timeout";
+        Duration sharedTimeout = Duration.ofMillis(100);
+
+        // Acquire with a 100ms lock
+        s.tryAcquire(contextFor(key, sharedTimeout));
+        // Simulate crashed caller — never complete or release
+        Thread.sleep(150); // past lockExpiresAt
+
+        // Second caller uses the SAME timeout — must still steal the stale lock
+        AcquireResult result = s.tryAcquire(contextFor(key, sharedTimeout));
+
+        assertThat(result)
+                .as("A stale lock should be stealable regardless of the caller's lockTimeout")
+                .isInstanceOf(AcquireResult.Acquired.class);
+    }
+
+    @Test
     void When_InFlightKey_Expect_BlocksAndReturnsDuplicateAfterCompletion() throws Exception {
         IdempotencyStore s = store();
         String key = "inflight-key";
@@ -584,16 +603,12 @@ public abstract class IdempotencyStoreContract {
         var ctx = contextFor("purge-stale-inprogress-1", Duration.ofMinutes(10), Duration.ofMillis(2));
         s.tryAcquire(ctx);
         Thread.sleep(50);
-        s.purgeExpired();
+        int purged = s.purgeExpired();
         // The entry TTL has not expired, so purge should keep it (even though lock expired).
-        // A correct purge must NOT remove an IN_PROGRESS entry whose TTL is still valid —
-        // the bug is that InMemory only checks lockExpiresAt and removes it prematurely.
-        // After a correct purge, tryAcquire on a stale lock returns Acquired (stolen).
-        // After the buggy purge (entry deleted), tryAcquire also returns Acquired — so this
-        // test is a companion to When_StaleInProgressBothLockAndTtlExpired; it drives the
-        // distinction that purge must require BOTH conditions before removing IN_PROGRESS.
-        var result = s.tryAcquire(ctx);
-        assertThat(result).isNotInstanceOf(AcquireResult.Acquired.class).isNotInstanceOf(AcquireResult.Duplicate.class);
+        // A correct purge must NOT remove an IN_PROGRESS entry whose TTL is still valid.
+        assertThat(purged)
+                .as("Purge must not remove IN_PROGRESS entry whose TTL is still valid")
+                .isEqualTo(0);
     }
 
     @Test

--- a/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
+++ b/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
@@ -673,4 +673,25 @@ public abstract class IdempotencyStoreContract {
 
         assertThat(result).isInstanceOf(AcquireResult.Acquired.class);
     }
+
+    @Test
+    void When_KeyReleasedAfterLockExpired_Expect_FailedRecordNotImmediatelyPurgeable() throws InterruptedException {
+        IdempotencyStore s = store();
+        String key = "failed-expiry-contract";
+
+        // Acquire with a very short lock
+        s.tryAcquire(contextFor(key, Duration.ofMillis(50)));
+
+        // Wait for the lock to expire, then release
+        Thread.sleep(100);
+        s.release(key);
+
+        // Purge immediately — the FAILED record should NOT be eligible yet.
+        int purged = s.purgeExpired();
+
+        assertThat(purged)
+                .as("FAILED record should survive an immediate purgeExpired() call; "
+                        + "its expires_at must be now + lockTimeout, not the already-past lock_expires_at")
+                .isEqualTo(0);
+    }
 }

--- a/providers/idempotency-inmemory/src/main/java/io/github/josipmusa/idempotency/inmemory/InMemoryIdempotencyStore.java
+++ b/providers/idempotency-inmemory/src/main/java/io/github/josipmusa/idempotency/inmemory/InMemoryIdempotencyStore.java
@@ -108,15 +108,10 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
             }
 
             // FAILED or stale IN_PROGRESS — attempt to claim the lock atomically.
-            // A stale lock is only stealable when the caller is willing to hold the lock
-            // longer than the original holder (context.lockTimeout > existing.lockTimeout).
-            // This prevents a short-lived caller from stealing a lock that was held briefly,
-            // ensuring such callers get LockTimeout instead.
+            // A stale lock (lockExpiresAt in the past) is claimable by any caller, regardless of
+            // the caller's lockTimeout. This matches JDBC behavior.
             if (existing.status() == Status.FAILED
-                    || (existing.lockExpiresAt() != null
-                            && existing.lockExpiresAt().isBefore(now)
-                            && existing.lockTimeout() != null
-                            && context.lockTimeout().compareTo(existing.lockTimeout()) > 0)) {
+                    || (existing.lockExpiresAt() != null && existing.lockExpiresAt().isBefore(now))) {
                 if (store.replace(context.key(), existing, newEntry)) {
                     return AcquireResult.acquired();
                 }

--- a/providers/idempotency-inmemory/src/main/java/io/github/josipmusa/idempotency/inmemory/InMemoryIdempotencyStore.java
+++ b/providers/idempotency-inmemory/src/main/java/io/github/josipmusa/idempotency/inmemory/InMemoryIdempotencyStore.java
@@ -111,7 +111,8 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
             // A stale lock (lockExpiresAt in the past) is claimable by any caller, regardless of
             // the caller's lockTimeout. This matches JDBC behavior.
             if (existing.status() == Status.FAILED
-                    || (existing.lockExpiresAt() != null && existing.lockExpiresAt().isBefore(now))) {
+                    || (existing.lockExpiresAt() != null
+                            && existing.lockExpiresAt().isBefore(now))) {
                 if (store.replace(context.key(), existing, newEntry)) {
                     return AcquireResult.acquired();
                 }

--- a/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStore.java
+++ b/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStore.java
@@ -51,9 +51,9 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
     private static final String DELETE_EXPIRED =
             "DELETE FROM idempotency_records WHERE idempotency_key = ? AND expires_at < ? AND status = 'COMPLETE'";
 
-    private static final String INSERT =
-            "INSERT INTO idempotency_records (idempotency_key, status, locked_at, lock_expires_at, expires_at, request_fingerprint) "
-                    + "VALUES (?, 'IN_PROGRESS', ?, ?, ?, ?)";
+    private static final String INSERT = "INSERT INTO idempotency_records "
+            + "(idempotency_key, status, locked_at, lock_expires_at, expires_at, request_fingerprint, lock_timeout_ms) "
+            + "VALUES (?, 'IN_PROGRESS', ?, ?, ?, ?, ?)";
 
     private static final String SELECT_FOR_UPDATE =
             "SELECT status, lock_expires_at, response_code, response_headers, response_body, completed_at, request_fingerprint "
@@ -63,7 +63,7 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
 
     private static final String STEAL_LOCK =
             "UPDATE idempotency_records SET status = 'IN_PROGRESS', locked_at = ?, lock_expires_at = ?, "
-                    + "request_fingerprint = ?, "
+                    + "request_fingerprint = ?, lock_timeout_ms = ?, "
                     + "response_code = NULL, response_headers = NULL, response_body = NULL, completed_at = NULL "
                     + "WHERE idempotency_key = ? AND (status = 'FAILED' OR (status = 'IN_PROGRESS' AND lock_expires_at < ?))";
 
@@ -73,9 +73,12 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
                     + "WHERE idempotency_key = ? AND status = 'IN_PROGRESS'";
 
     private static final String RELEASE =
-            "UPDATE idempotency_records SET status = 'FAILED', expires_at = lock_expires_at, locked_at = NULL, lock_expires_at = NULL, "
+            "UPDATE idempotency_records SET status = 'FAILED', expires_at = ?, locked_at = NULL, lock_expires_at = NULL, "
                     + "response_code = NULL, response_headers = NULL, response_body = NULL "
                     + "WHERE idempotency_key = ? AND status = 'IN_PROGRESS'";
+
+    private static final String SELECT_LOCK_TIMEOUT_FOR_UPDATE = "SELECT lock_timeout_ms FROM idempotency_records "
+            + "WHERE idempotency_key = ? AND status = 'IN_PROGRESS' FOR UPDATE";
 
     private static final String EXTEND_LOCK =
             "UPDATE idempotency_records SET lock_expires_at = ? WHERE idempotency_key = ? AND status = 'IN_PROGRESS'";
@@ -269,12 +272,35 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
     @Override
     public void release(String key) {
         try (Connection conn = dataSource.getConnection()) {
-            try (PreparedStatement ps = conn.prepareStatement(RELEASE)) {
-                ps.setString(1, key);
-                int updated = ps.executeUpdate();
-                if (updated == 0) {
-                    throw new IdempotencyStoreException(diagnoseMissingInProgress(conn, key, "release"));
+            conn.setAutoCommit(false);
+            try {
+                long lockTimeoutMs;
+                try (PreparedStatement sel = conn.prepareStatement(SELECT_LOCK_TIMEOUT_FOR_UPDATE)) {
+                    sel.setString(1, key);
+                    try (ResultSet rs = sel.executeQuery()) {
+                        if (!rs.next()) {
+                            throw new IdempotencyStoreException(diagnoseMissingInProgress(conn, key, "release"));
+                        }
+                        lockTimeoutMs = rs.getLong("lock_timeout_ms");
+                    }
                 }
+                Instant failedExpiry = clock.instant().plus(Duration.ofMillis(lockTimeoutMs));
+                try (PreparedStatement ps = conn.prepareStatement(RELEASE)) {
+                    ps.setTimestamp(1, Timestamp.from(failedExpiry));
+                    ps.setString(2, key);
+                    if (ps.executeUpdate() == 0) {
+                        throw new IdempotencyStoreException(diagnoseMissingInProgress(conn, key, "release"));
+                    }
+                }
+                conn.commit();
+            } catch (IdempotencyStoreException e) {
+                rollbackQuietly(conn);
+                throw e;
+            } catch (SQLException e) {
+                rollbackQuietly(conn);
+                throw new IdempotencyStoreException("Failed to release key '" + key + "'", e);
+            } finally {
+                resetAutoCommit(conn);
             }
         } catch (SQLException e) {
             throw new IdempotencyStoreException("Failed to release key '" + key + "'", e);
@@ -340,6 +366,7 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
                 ins.setTimestamp(3, Timestamp.from(now.plus(context.lockTimeout())));
                 ins.setTimestamp(4, Timestamp.from(now.plus(context.ttl())));
                 ins.setString(5, context.requestFingerprint());
+                ins.setLong(6, context.lockTimeout().toMillis());
                 ins.executeUpdate();
                 return true;
             } catch (SQLException e) {
@@ -411,8 +438,9 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
             ps.setTimestamp(1, Timestamp.from(now));
             ps.setTimestamp(2, Timestamp.from(now.plus(context.lockTimeout())));
             ps.setString(3, context.requestFingerprint());
-            ps.setString(4, context.key());
-            ps.setTimestamp(5, Timestamp.from(now));
+            ps.setLong(4, context.lockTimeout().toMillis());
+            ps.setString(5, context.key());
+            ps.setTimestamp(6, Timestamp.from(now));
             return ps.executeUpdate() > 0;
         }
     }

--- a/providers/idempotency-jdbc/src/main/resources/idempotency-schema-mysql.sql
+++ b/providers/idempotency-jdbc/src/main/resources/idempotency-schema-mysql.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS idempotency_records (
     response_headers  TEXT          NULL,
     response_body     BLOB          NULL,
     request_fingerprint VARCHAR(64) NULL,
+    lock_timeout_ms   BIGINT        NOT NULL DEFAULT 0,
     completed_at      TIMESTAMP(6)  NULL,
     created_at        TIMESTAMP(6)  DEFAULT CURRENT_TIMESTAMP(6) NOT NULL,
     expires_at        TIMESTAMP(6)  NULL,

--- a/providers/idempotency-jdbc/src/main/resources/idempotency-schema-postgresql.sql
+++ b/providers/idempotency-jdbc/src/main/resources/idempotency-schema-postgresql.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS idempotency_records (
     response_headers  TEXT          NULL,
     response_body     BYTEA         NULL,
     request_fingerprint VARCHAR(64) NULL,
+    lock_timeout_ms   BIGINT        NOT NULL DEFAULT 0,
     completed_at      TIMESTAMP(6)  NULL,
     created_at        TIMESTAMP(6)  DEFAULT CURRENT_TIMESTAMP NOT NULL,
     expires_at        TIMESTAMP(6)  NULL,

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfiguration.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfiguration.java
@@ -69,8 +69,10 @@ public class IdempotencyAutoConfiguration {
             IdempotencyStore store,
             IdempotencyConfig config,
             RequestMappingHandlerMapping handlerMapping,
-            IdempotentHandlerRegistry registry) {
-        return new IdempotencyFilter(engine, store, config, handlerMapping, registry);
+            IdempotentHandlerRegistry registry,
+            IdempotencyProperties properties) {
+        return new IdempotencyFilter(engine, store, config, handlerMapping, registry,
+                properties.getMaxBodyBytes());
     }
 
     @Bean

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfiguration.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfiguration.java
@@ -7,6 +7,7 @@ import io.github.josipmusa.idempotency.spring.IdempotencyFilter;
 import io.github.josipmusa.idempotency.spring.IdempotentHandlerRegistry;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -36,8 +37,10 @@ public class IdempotencyAutoConfiguration {
     @Bean(destroyMethod = "shutdownNow")
     @ConditionalOnMissingBean(name = "idempotencyScheduler")
     public ScheduledExecutorService idempotencyScheduler() {
-        return Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, "idempotency-heartbeat");
+        int poolSize = Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+        AtomicInteger counter = new AtomicInteger(0);
+        return Executors.newScheduledThreadPool(poolSize, r -> {
+            Thread t = new Thread(r, "idempotency-heartbeat-" + counter.incrementAndGet());
             t.setDaemon(true);
             return t;
         });

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfiguration.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfiguration.java
@@ -71,8 +71,7 @@ public class IdempotencyAutoConfiguration {
             RequestMappingHandlerMapping handlerMapping,
             IdempotentHandlerRegistry registry,
             IdempotencyProperties properties) {
-        return new IdempotencyFilter(engine, store, config, handlerMapping, registry,
-                properties.getMaxBodyBytes());
+        return new IdempotencyFilter(engine, store, config, handlerMapping, registry, properties.getMaxBodyBytes());
     }
 
     @Bean

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyProperties.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyProperties.java
@@ -2,7 +2,6 @@ package io.github.josipmusa.idempotency.springboot;
 
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.core.Ordered;
 
 @ConfigurationProperties(prefix = "idempotency")
 public class IdempotencyProperties {
@@ -10,7 +9,7 @@ public class IdempotencyProperties {
     private String keyHeader = "Idempotency-Key";
     private Duration defaultTtl = Duration.ofHours(24);
     private Duration defaultLockTimeout = Duration.ofSeconds(10);
-    private int filterOrder = Ordered.HIGHEST_PRECEDENCE + 1;
+    private int filterOrder = 0;
     private Purge purge = new Purge();
 
     public String getKeyHeader() {

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyProperties.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyProperties.java
@@ -10,6 +10,7 @@ public class IdempotencyProperties {
     private Duration defaultTtl = Duration.ofHours(24);
     private Duration defaultLockTimeout = Duration.ofSeconds(10);
     private int filterOrder = 0;
+    private long maxBodyBytes = 1_048_576L; // 1 MiB
     private Purge purge = new Purge();
 
     public String getKeyHeader() {
@@ -42,6 +43,14 @@ public class IdempotencyProperties {
 
     public void setFilterOrder(int filterOrder) {
         this.filterOrder = filterOrder;
+    }
+
+    public long getMaxBodyBytes() {
+        return maxBodyBytes;
+    }
+
+    public void setMaxBodyBytes(long maxBodyBytes) {
+        this.maxBodyBytes = maxBodyBytes;
     }
 
     public Purge getPurge() {

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfiguration.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfiguration.java
@@ -3,11 +3,14 @@ package io.github.josipmusa.idempotency.springboot;
 import io.github.josipmusa.core.IdempotencyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.support.CronExpression;
 
@@ -37,5 +40,19 @@ public class IdempotencyPurgeAutoConfiguration {
                     }
                 },
                 cron);
+    }
+
+    @Bean
+    public SmartInitializingSingleton idempotencyPurgeSchedulingWarner(ApplicationContext applicationContext) {
+        return () -> {
+            String[] schedulingProcessors =
+                    applicationContext.getBeanNamesForType(ScheduledAnnotationBeanPostProcessor.class);
+            if (schedulingProcessors.length == 0) {
+                log.warn("idempotency.purge.enabled is true but @EnableScheduling was not detected. "
+                        + "Expired idempotency records will NOT be purged automatically. "
+                        + "Add @EnableScheduling to your application class, "
+                        + "or set idempotency.purge.enabled=false to suppress this warning.");
+            }
+        };
     }
 }

--- a/spring/idempotency-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring/idempotency-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -22,7 +22,7 @@
       "name": "idempotency.filter-order",
       "type": "java.lang.Integer",
       "description": "Order of the idempotency servlet filter in the filter chain. Lower values execute earlier.",
-      "defaultValue": -2147483647
+      "defaultValue": 0
     },
     {
       "name": "idempotency.purge.enabled",

--- a/spring/idempotency-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring/idempotency-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -35,6 +35,12 @@
       "type": "java.lang.String",
       "description": "Cron expression controlling how often expired idempotency records are purged.",
       "defaultValue": "0 0 * * * *"
+    },
+    {
+      "name": "idempotency.max-body-bytes",
+      "type": "java.lang.Long",
+      "description": "Maximum allowed request body size in bytes for idempotency processing. Requests exceeding this limit receive HTTP 413. Set to -1 to disable the limit.",
+      "defaultValue": 1048576
     }
   ]
 }

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
@@ -13,7 +13,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.core.Ordered;
+
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 class IdempotencyAutoConfigurationTest {
@@ -103,7 +103,7 @@ class IdempotencyAutoConfigurationTest {
                 .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
                 .run(context -> {
                     FilterRegistrationBean<?> registration = context.getBean(FilterRegistrationBean.class);
-                    assertThat(registration.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE + 1);
+                    assertThat(registration.getOrder()).isEqualTo(0);
                 });
     }
 

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
-
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 class IdempotencyAutoConfigurationTest {

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
@@ -119,6 +119,16 @@ class IdempotencyAutoConfigurationTest {
     }
 
     @Test
+    void When_CustomMaxBodyBytes_Expect_AppliedToFilter() {
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
+                .withPropertyValues("idempotency.max-body-bytes=2097152")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(IdempotencyFilter.class);
+                });
+    }
+
+    @Test
     void When_NonServletApplication_Expect_NoBeanCreated() {
         new ApplicationContextRunner()
                 .withConfiguration(AutoConfigurations.of(IdempotencyAutoConfiguration.class))

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyPurgeAutoConfigurationTest.java
@@ -83,4 +83,15 @@ class IdempotencyPurgeAutoConfigurationTest {
             assertThatCode(() -> taskCaptor.getValue().run()).doesNotThrowAnyException();
         });
     }
+
+    @Test
+    void When_EnableSchedulingAbsent_Expect_WarnerBeanPresent() {
+        contextRunner
+                .withBean(IdempotencyStore.class, () -> mock(IdempotencyStore.class))
+                .run(context -> {
+                    assertThat(context).hasSingleBean(SchedulingConfigurer.class);
+                    assertThat(context).hasBean("idempotencyPurgeSchedulingWarner");
+                    assertThat(context).hasNotFailed();
+                });
+    }
 }

--- a/spring/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
+++ b/spring/idempotency-spring/src/main/java/io/github/josipmusa/idempotency/spring/IdempotencyFilter.java
@@ -50,12 +50,30 @@ public class IdempotencyFilter extends OncePerRequestFilter {
     private static final String ERROR_KEY_TOO_LONG = "Idempotency-Key must not exceed 255 characters";
     private static final String ERROR_LOCK_TIMEOUT = "Request with this key is already being processed";
     private static final String ERROR_FINGERPRINT_MISMATCH = "Idempotency-Key reused with a different request body";
+    private static final String ERROR_BODY_TOO_LARGE = "Request body exceeds maximum allowed size";
+    private static final long NO_LIMIT = -1;
 
     private final IdempotencyEngine engine;
     private final IdempotencyStore store;
     private final IdempotencyConfig config;
     private final RequestMappingHandlerMapping handlerMapping;
     private final IdempotentHandlerRegistry registry;
+    private final long maxBodyBytes;
+
+    public IdempotencyFilter(
+            IdempotencyEngine engine,
+            IdempotencyStore store,
+            IdempotencyConfig config,
+            RequestMappingHandlerMapping handlerMapping,
+            IdempotentHandlerRegistry registry,
+            long maxBodyBytes) {
+        this.engine = Objects.requireNonNull(engine, "engine must not be null");
+        this.store = Objects.requireNonNull(store, "store must not be null");
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.handlerMapping = Objects.requireNonNull(handlerMapping, "handlerMapping must not be null");
+        this.registry = Objects.requireNonNull(registry, "registry must not be null");
+        this.maxBodyBytes = maxBodyBytes;
+    }
 
     public IdempotencyFilter(
             IdempotencyEngine engine,
@@ -63,11 +81,7 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             IdempotencyConfig config,
             RequestMappingHandlerMapping handlerMapping,
             IdempotentHandlerRegistry registry) {
-        this.engine = Objects.requireNonNull(engine, "engine must not be null");
-        this.store = Objects.requireNonNull(store, "store must not be null");
-        this.config = Objects.requireNonNull(config, "config must not be null");
-        this.handlerMapping = Objects.requireNonNull(handlerMapping, "handlerMapping must not be null");
-        this.registry = Objects.requireNonNull(registry, "registry must not be null");
+        this(engine, store, config, handlerMapping, registry, NO_LIMIT);
     }
 
     @Override
@@ -100,6 +114,11 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         // Force reading the body so ContentCachingRequestWrapper caches it
         wrappedRequest.getInputStream().readAllBytes();
         String fingerprint = RequestFingerprint.of(wrappedRequest.getContentAsByteArray());
+
+        if (maxBodyBytes != NO_LIMIT && wrappedRequest.getContentAsByteArray().length > maxBodyBytes) {
+            writeJsonError(response, 413, ERROR_BODY_TOO_LARGE);
+            return;
+        }
 
         IdempotencyContext context;
         try {

--- a/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
+++ b/spring/idempotency-spring/src/test/java/io/github/josipmusa/idempotency/spring/IdempotencyFilterTest.java
@@ -324,6 +324,22 @@ class IdempotencyFilterTest {
     }
 
     @Test
+    void When_RequestBodyExceedsLimit_Expect_Returns413() throws Exception {
+        setupAnnotatedHandler(AnnotationHelper.annotation(true));
+        request.addHeader("Idempotency-Key", "key-123");
+        request.setContent("this body is definitely longer than ten bytes".getBytes());
+
+        IdempotencyFilter limitedFilter =
+                new IdempotencyFilter(engine, store, IdempotencyConfig.defaults(), handlerMapping, registry, 10);
+
+        limitedFilter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(413);
+        assertThat(response.getContentAsString()).contains("Request body exceeds maximum allowed size");
+        verifyNoInteractions(engine);
+    }
+
+    @Test
     void When_FingerprintMismatch_Expect_Returns422() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "key-1");


### PR DESCRIPTION
## Summary

This PR addresses 9 issues found during code review, spanning correctness bugs, missing features, and documentation gaps.

## Changes

| Commit | Issue | Description |
|--------|-------|-------------|
| Fix BOM parent inheritance | #42 | `idempotency-bom` now inherits `<version>` from parent instead of hardcoding |
| Change default filter order | #40 | Default `filterOrder` is `0` instead of `HIGHEST_PRECEDENCE + 1` |
| Sized heartbeat thread pool | #41 | Single-thread scheduler replaced with `max(2, availableProcessors/2)` pool |
| Body size limit | #43 | `IdempotencyFilter` returns `413` when body exceeds `maxBodyBytes` (default 1 MiB) |
| Lock steal condition fix | #44 | In-memory store no longer requires caller timeout > existing timeout for steal |
| JDBC FAILED record TTL | #45 | `release()` computes `expires_at = now + lockTimeout` so FAILED records survive their TTL |
| Contract test for steal | #46 | New contract test `When_StaleLockAndSameLockTimeout_Expect_IsStolen` |
| @EnableScheduling warning | #47 | Logs WARN at startup when purge is enabled but `@EnableScheduling` is missing |
| Builder Javadoc | #48 | Comprehensive Javadoc on `IdempotencyConfig.Builder` methods |

## Testing

- All existing tests pass
- New tests added for body size limit (filter + auto-config), lock steal condition, JDBC FAILED TTL, and scheduling warning
- `mvn verify` passes clean (spotless, compile, test)

Closes #40, closes #41, closes #42, closes #43, closes #44, closes #45, closes #46, closes #47, closes #48