### PR TITLE
Fix pre-release security and correctness issues

### DIFF
--- a/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyConfig.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyConfig.java
@@ -2,6 +2,7 @@ package io.github.josipmusa.core;
 
 import java.time.Duration;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Application-level defaults for idempotency behavior.
@@ -60,6 +61,9 @@ public final class IdempotencyConfig {
     }
 
     public static final class Builder {
+        // RFC 7230 §3.2.6: header field names are tokens composed of tchar characters
+        private static final Pattern HEADER_TOKEN = Pattern.compile("[!#$%&'*+\\-.0-9A-Za-z^_`|~]+");
+
         private Duration defaultTtl = Duration.ofHours(24);
         private Duration defaultLockTimeout = Duration.ofSeconds(10);
         private String keyHeader = "Idempotency-Key";
@@ -142,6 +146,10 @@ public final class IdempotencyConfig {
             }
             if (keyHeader == null || keyHeader.isBlank()) {
                 throw new IllegalArgumentException("keyHeader must not be blank");
+            }
+            if (!HEADER_TOKEN.matcher(keyHeader).matches()) {
+                throw new IllegalArgumentException("keyHeader '" + keyHeader
+                        + "' contains characters not permitted in an HTTP header name (RFC 7230 token)");
             }
             return new IdempotencyConfig(this);
         }

--- a/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyContext.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/IdempotencyContext.java
@@ -32,7 +32,8 @@ import java.util.Objects;
 public record IdempotencyContext(String key, Duration ttl, Duration lockTimeout, String requestFingerprint) {
 
     private static final Duration MIN_LOCK_TIMEOUT = Duration.ofMillis(2);
-    private static final int MAX_KEY_LENGTH = 255;
+    public static final int MAX_KEY_LENGTH = 255;
+    private static final int FINGERPRINT_LENGTH = 64;
 
     public IdempotencyContext {
         Objects.requireNonNull(key, "key must not be null");
@@ -54,6 +55,10 @@ public record IdempotencyContext(String key, Duration ttl, Duration lockTimeout,
         Objects.requireNonNull(requestFingerprint, "requestFingerprint must not be null");
         if (requestFingerprint.isBlank()) {
             throw new IllegalArgumentException("requestFingerprint must not be blank");
+        }
+        if (requestFingerprint.length() != FINGERPRINT_LENGTH) {
+            throw new IllegalArgumentException("requestFingerprint must be " + FINGERPRINT_LENGTH
+                    + " characters (SHA-256 hex digest), got: " + requestFingerprint.length());
         }
     }
 }

--- a/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyConfigTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyConfigTest.java
@@ -59,4 +59,28 @@ class IdempotencyConfigTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("defaultLockTimeout must be at least 2ms");
     }
+
+    @Test
+    void When_KeyHeaderWithSpaceProvided_Expect_ThrowsIllegalArgumentException() {
+        assertThatThrownBy(
+                        () -> IdempotencyConfig.builder().keyHeader("My Header").build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not permitted in an HTTP header name");
+    }
+
+    @Test
+    void When_KeyHeaderWithCrLfProvided_Expect_ThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> IdempotencyConfig.builder()
+                        .keyHeader("X-Key\r\nX-Injected")
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not permitted in an HTTP header name");
+    }
+
+    @Test
+    void When_KeyHeaderIsValidRfc7230Token_Expect_BuildsSuccessfully() {
+        IdempotencyConfig config =
+                IdempotencyConfig.builder().keyHeader("X-Idempotency-Key").build();
+        assertThat(config.keyHeader()).isEqualTo("X-Idempotency-Key");
+    }
 }

--- a/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyContextTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyContextTest.java
@@ -1,0 +1,55 @@
+package io.github.josipmusa.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class IdempotencyContextTest {
+
+    private static final String VALID_FINGERPRINT = "a".repeat(64);
+    private static final Duration TTL = Duration.ofHours(1);
+    private static final Duration LOCK_TIMEOUT = Duration.ofSeconds(10);
+
+    @Test
+    void When_ValidFingerprint64Chars_Expect_ConstructsSuccessfully() {
+        IdempotencyContext ctx = new IdempotencyContext("key", TTL, LOCK_TIMEOUT, VALID_FINGERPRINT);
+        assertThat(ctx.requestFingerprint()).isEqualTo(VALID_FINGERPRINT);
+    }
+
+    @Test
+    void When_FingerprintTooShort_Expect_ThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> new IdempotencyContext("key", TTL, LOCK_TIMEOUT, "tooshort"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requestFingerprint must be 64 characters");
+    }
+
+    @Test
+    void When_FingerprintTooLong_Expect_ThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> new IdempotencyContext("key", TTL, LOCK_TIMEOUT, "a".repeat(65)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requestFingerprint must be 64 characters");
+    }
+
+    @Test
+    void When_BlankFingerprint_Expect_ThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> new IdempotencyContext("key", TTL, LOCK_TIMEOUT, "   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requestFingerprint must not be blank");
+    }
+
+    @Test
+    void When_KeyTooLong_Expect_ThrowsIllegalArgumentException() {
+        assertThatThrownBy(() -> new IdempotencyContext("k".repeat(256), TTL, LOCK_TIMEOUT, VALID_FINGERPRINT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("key length must not exceed 255");
+    }
+
+    @Test
+    void When_KeyExactlyAtMaxLength_Expect_ConstructsSuccessfully() {
+        IdempotencyContext ctx = new IdempotencyContext(
+                "k".repeat(IdempotencyContext.MAX_KEY_LENGTH), TTL, LOCK_TIMEOUT, VALID_FINGERPRINT);
+        assertThat(ctx.key()).hasSize(IdempotencyContext.MAX_KEY_LENGTH);
+    }
+}

--- a/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyEngineTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/core/IdempotencyEngineTest.java
@@ -40,7 +40,7 @@ class IdempotencyEngineTest {
     }
 
     private IdempotencyContext defaultContext(String key) {
-        return new IdempotencyContext(key, Duration.ofHours(1), Duration.ofSeconds(5), "test-fingerprint");
+        return new IdempotencyContext(key, Duration.ofHours(1), Duration.ofSeconds(5), "a".repeat(64));
     }
 
     private StoredResponse anyStoredResponse() {
@@ -134,7 +134,7 @@ class IdempotencyEngineTest {
     @Test
     void When_LongRunningAction_Expect_HeartbeatExtendsLock() throws Exception {
         IdempotencyContext context =
-                new IdempotencyContext("hb-key", Duration.ofHours(1), Duration.ofMillis(100), "test-fingerprint");
+                new IdempotencyContext("hb-key", Duration.ofHours(1), Duration.ofMillis(100), "a".repeat(64));
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
         engine.execute(context, () -> Thread.sleep(300));
@@ -145,7 +145,7 @@ class IdempotencyEngineTest {
     @Test
     void When_ActionCompletes_Expect_HeartbeatStops() throws Exception {
         IdempotencyContext context =
-                new IdempotencyContext("hb-stop-key", Duration.ofHours(1), Duration.ofMillis(100), "test-fingerprint");
+                new IdempotencyContext("hb-stop-key", Duration.ofHours(1), Duration.ofMillis(100), "a".repeat(64));
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
         engine.execute(context, () -> {});
@@ -170,7 +170,7 @@ class IdempotencyEngineTest {
     @Test
     void When_ActionThrows_Expect_HeartbeatStops() throws Exception {
         IdempotencyContext context =
-                new IdempotencyContext("hb-throw-key", Duration.ofHours(1), Duration.ofMillis(100), "test-fingerprint");
+                new IdempotencyContext("hb-throw-key", Duration.ofHours(1), Duration.ofMillis(100), "a".repeat(64));
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
 
         try {
@@ -265,7 +265,7 @@ class IdempotencyEngineTest {
     @Test
     void When_HeartbeatExtendLockThrows_Expect_HeartbeatContinues() throws Exception {
         IdempotencyContext context =
-                new IdempotencyContext("hb-error-key", Duration.ofHours(1), Duration.ofMillis(100), "test-fingerprint");
+                new IdempotencyContext("hb-error-key", Duration.ofHours(1), Duration.ofMillis(100), "a".repeat(64));
         when(store.tryAcquire(any())).thenReturn(AcquireResult.acquired());
         doThrow(new IdempotencyStoreException("connection lost")).when(store).extendLock(any(), any());
 

--- a/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
+++ b/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
@@ -24,18 +24,23 @@ import org.junit.jupiter.api.Test;
 
 public abstract class IdempotencyStoreContract {
 
+    // 64-character fingerprint constants (SHA-256 hex length) used across test fixtures
+    protected static final String FINGERPRINT_DEFAULT = "0".repeat(64);
+    protected static final String FINGERPRINT_A = "a".repeat(64);
+    protected static final String FINGERPRINT_B = "b".repeat(64);
+
     protected abstract IdempotencyStore store();
 
     protected IdempotencyContext contextFor(String key) {
-        return new IdempotencyContext(key, Duration.ofHours(1), Duration.ofSeconds(5), "default-fingerprint");
+        return new IdempotencyContext(key, Duration.ofHours(1), Duration.ofSeconds(5), FINGERPRINT_DEFAULT);
     }
 
     protected IdempotencyContext contextFor(String key, Duration lockTimeout) {
-        return new IdempotencyContext(key, Duration.ofHours(1), lockTimeout, "default-fingerprint");
+        return new IdempotencyContext(key, Duration.ofHours(1), lockTimeout, FINGERPRINT_DEFAULT);
     }
 
     private IdempotencyContext contextFor(String key, Duration ttl, Duration lockTimeout) {
-        return new IdempotencyContext(key, ttl, lockTimeout, "default-fingerprint");
+        return new IdempotencyContext(key, ttl, lockTimeout, FINGERPRINT_DEFAULT);
     }
 
     protected IdempotencyContext contextFor(String key, String fingerprint) {
@@ -636,7 +641,7 @@ public abstract class IdempotencyStoreContract {
     @Test
     void When_SameKeyAndSameFingerprint_Expect_Duplicate() {
         IdempotencyStore s = store();
-        var context = contextFor("fp-same", "sha256-abc123");
+        var context = contextFor("fp-same", FINGERPRINT_A);
         s.tryAcquire(context);
         s.complete("fp-same", sampleResponse(), Duration.ofHours(1));
 
@@ -648,27 +653,27 @@ public abstract class IdempotencyStoreContract {
     @Test
     void When_SameKeyButDifferentFingerprint_Expect_FingerprintMismatch() {
         IdempotencyStore s = store();
-        var original = contextFor("fp-diff", "sha256-original");
+        var original = contextFor("fp-diff", FINGERPRINT_A);
         s.tryAcquire(original);
         s.complete("fp-diff", sampleResponse(), Duration.ofHours(1));
 
-        var reused = contextFor("fp-diff", "sha256-different");
+        var reused = contextFor("fp-diff", FINGERPRINT_B);
         var result = s.tryAcquire(reused);
 
         assertThat(result).isInstanceOf(AcquireResult.FingerprintMismatch.class);
         var mismatch = (AcquireResult.FingerprintMismatch) result;
-        assertThat(mismatch.storedFingerprint()).isEqualTo("sha256-original");
-        assertThat(mismatch.receivedFingerprint()).isEqualTo("sha256-different");
+        assertThat(mismatch.storedFingerprint()).isEqualTo(FINGERPRINT_A);
+        assertThat(mismatch.receivedFingerprint()).isEqualTo(FINGERPRINT_B);
     }
 
     @Test
     void When_KeyReleasedAndReAcquiredWithDifferentFingerprint_Expect_Acquired() {
         IdempotencyStore s = store();
-        var first = contextFor("fp-reacquire", "sha256-first");
+        var first = contextFor("fp-reacquire", FINGERPRINT_A);
         s.tryAcquire(first);
         s.release("fp-reacquire");
 
-        var second = contextFor("fp-reacquire", "sha256-second");
+        var second = contextFor("fp-reacquire", FINGERPRINT_B);
         var result = s.tryAcquire(second);
 
         assertThat(result).isInstanceOf(AcquireResult.Acquired.class);

--- a/providers/idempotency-inmemory/src/main/java/io/github/josipmusa/idempotency/inmemory/InMemoryIdempotencyStore.java
+++ b/providers/idempotency-inmemory/src/main/java/io/github/josipmusa/idempotency/inmemory/InMemoryIdempotencyStore.java
@@ -190,11 +190,11 @@ public class InMemoryIdempotencyStore implements IdempotencyStore {
      * <ul>
      *   <li>{@code COMPLETE} and {@code FAILED} — removed when
      *       {@code expiresAt} is in the past</li>
-     *   <li>{@code IN_PROGRESS} — removed when {@code lockExpiresAt}
-     *       is in the past, indicating the previous holder crashed or
-     *       timed out. The next {@link #tryAcquire} caller will insert
-     *       a fresh entry rather than stealing — the outcome is
-     *       identical.</li>
+     *   <li>{@code IN_PROGRESS} — removed only when <em>both</em>
+     *       {@code lockExpiresAt} and {@code expiresAt} are in the past.
+     *       Entries whose lock has expired but whose TTL has not are
+     *       intentionally kept — they remain eligible for lock stealing
+     *       by the next {@link #tryAcquire} caller.</li>
      * </ul>
      *
      * <p>This method does not self-schedule. In Spring Boot applications,

--- a/providers/idempotency-jdbc/src/test/java/io/github/josipmusa/idempotency/jdbc/MysqlJdbcIdempotencyStoreTest.java
+++ b/providers/idempotency-jdbc/src/test/java/io/github/josipmusa/idempotency/jdbc/MysqlJdbcIdempotencyStoreTest.java
@@ -69,7 +69,7 @@ class MysqlJdbcIdempotencyStoreTest extends IdempotencyStoreContract {
 
         JdbcIdempotencyStore failingStore = new JdbcIdempotencyStore(exhaustedDs, false);
         IdempotencyContext context =
-                new IdempotencyContext("key", Duration.ofHours(1), Duration.ofSeconds(5), "test-fingerprint");
+                new IdempotencyContext("key", Duration.ofHours(1), Duration.ofSeconds(5), "a".repeat(64));
 
         assertThatThrownBy(() -> failingStore.tryAcquire(context)).isInstanceOf(IdempotencyStoreException.class);
     }

--- a/providers/idempotency-jdbc/src/test/java/io/github/josipmusa/idempotency/jdbc/PostgresJdbcIdempotencyStoreTest.java
+++ b/providers/idempotency-jdbc/src/test/java/io/github/josipmusa/idempotency/jdbc/PostgresJdbcIdempotencyStoreTest.java
@@ -69,7 +69,7 @@ class PostgresJdbcIdempotencyStoreTest extends IdempotencyStoreContract {
 
         JdbcIdempotencyStore failingStore = new JdbcIdempotencyStore(exhaustedDs, false);
         IdempotencyContext context =
-                new IdempotencyContext("key", Duration.ofHours(1), Duration.ofSeconds(5), "test-fingerprint");
+                new IdempotencyContext("key", Duration.ofHours(1), Duration.ofSeconds(5), "a".repeat(64));
 
         assertThat(failingStore).isNotNull();
         org.assertj.core.api.Assertions.assertThatThrownBy(() -> failingStore.tryAcquire(context))

--- a/spring/idempotency-spring-web/src/main/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilter.java
+++ b/spring/idempotency-spring-web/src/main/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilter.java
@@ -110,24 +110,28 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             return;
         }
 
-        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
-        // Force reading the body so ContentCachingRequestWrapper caches it
-        wrappedRequest.getInputStream().readAllBytes();
-        String fingerprint = RequestFingerprint.of(wrappedRequest.getContentAsByteArray());
-
-        if (maxBodyBytes != NO_LIMIT && wrappedRequest.getContentAsByteArray().length > maxBodyBytes) {
-            writeJsonError(response, 413, ERROR_BODY_TOO_LARGE);
-            return;
-        }
-
-        IdempotencyContext context;
-        try {
-            context = new IdempotencyContext(
-                    key, resolvedIdempotent.ttl(), resolvedIdempotent.lockTimeout(), fingerprint);
-        } catch (IllegalArgumentException e) {
+        if (key.length() > IdempotencyContext.MAX_KEY_LENGTH) {
             writeJsonError(response, 422, ERROR_KEY_TOO_LONG);
             return;
         }
+
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+        // Read the body into the cache. When a size limit is configured, read only up to
+        // limit + 1 bytes so we detect oversized bodies without buffering the full payload.
+        if (maxBodyBytes != NO_LIMIT) {
+            long safeLimit = maxBodyBytes >= Integer.MAX_VALUE ? Integer.MAX_VALUE : maxBodyBytes + 1;
+            wrappedRequest.getInputStream().readNBytes((int) safeLimit);
+            if (wrappedRequest.getContentAsByteArray().length > maxBodyBytes) {
+                writeJsonError(response, 413, ERROR_BODY_TOO_LARGE);
+                return;
+            }
+        } else {
+            wrappedRequest.getInputStream().readAllBytes();
+        }
+        String fingerprint = RequestFingerprint.of(wrappedRequest.getContentAsByteArray());
+
+        IdempotencyContext context =
+                new IdempotencyContext(key, resolvedIdempotent.ttl(), resolvedIdempotent.lockTimeout(), fingerprint);
 
         ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
         ExecutionResult result;
@@ -175,6 +179,7 @@ public class IdempotencyFilter extends OncePerRequestFilter {
                     }
                 });
                 response.setHeader(HEADER_IDEMPOTENT_REPLAYED, "true");
+                response.setHeader("Cache-Control", "no-store");
                 response.setContentLength(stored.body().length);
                 response.getOutputStream().write(stored.body());
             }
@@ -222,6 +227,9 @@ public class IdempotencyFilter extends OncePerRequestFilter {
         return value.replace("\\", "\\\\")
                 .replace("\"", "\\\"")
                 .replace("\n", "\\n")
-                .replace("\r", "\\r");
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
+                .replace("\b", "\\b")
+                .replace("\f", "\\f");
     }
 }

--- a/spring/idempotency-spring-web/src/test/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilterTest.java
+++ b/spring/idempotency-spring-web/src/test/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilterTest.java
@@ -340,6 +340,38 @@ class IdempotencyFilterTest {
     }
 
     @Test
+    void When_DuplicateResult_Expect_CacheControlNoStoreSet() throws Exception {
+        setupAnnotatedHandler(AnnotationHelper.annotation(true));
+        request.addHeader("Idempotency-Key", "test-key");
+        when(engine.execute(any(), any())).thenReturn(ExecutionResult.duplicate(storedResponse()));
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
+    }
+
+    @Test
+    void When_RequestBodyExactlyAtLimit_Expect_ProceedsNormally() throws Exception {
+        setupAnnotatedHandler(AnnotationHelper.annotation(true));
+        request.addHeader("Idempotency-Key", "key-123");
+        request.setContent("0123456789".getBytes()); // exactly 10 bytes
+        IdempotencyFilter limitedFilter =
+                new IdempotencyFilter(engine, store, IdempotencyConfig.defaults(), handlerMapping, registry, 10);
+        doAnswer(invocation -> {
+                    ThrowingRunnable action = invocation.getArgument(1);
+                    action.run();
+                    return ExecutionResult.executed();
+                })
+                .when(engine)
+                .execute(any(), any());
+
+        limitedFilter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isNotEqualTo(413);
+        verify(engine).execute(any(), any());
+    }
+
+    @Test
     void When_FingerprintMismatch_Expect_Returns422() throws Exception {
         setupAnnotatedHandler(AnnotationHelper.annotation(true));
         request.addHeader("Idempotency-Key", "key-1");


### PR DESCRIPTION
## Summary

- **Body size check now bounds memory usage**: `readAllBytes()` is replaced with `readNBytes(maxBodyBytes + 1)` when a limit is configured, preventing full payload buffering before the 413 check (DoS mitigation)
- **`IllegalArgumentException` catch removed from filter**: key length is pre-checked against `IdempotencyContext.MAX_KEY_LENGTH` so developer misconfiguration (bad TTL, lockTimeout) surfaces as a 500 instead of a misleading 422 to clients
- **`Cache-Control: no-store` added to replayed responses**: prevents proxy caches from treating a replayed idempotent response as if it were the original
- **`purgeExpired()` Javadoc corrected**: the IN_PROGRESS purge condition requires *both* `lockExpiresAt` AND `expiresAt` to have expired — the old Javadoc only mentioned `lockExpiresAt`
- **`keyHeader` validated against RFC 7230 token characters**: `IdempotencyConfig.Builder.build()` now rejects names containing spaces, CR/LF, or other non-token characters
- **`requestFingerprint` length validated**: `IdempotencyContext` now rejects fingerprints that are not exactly 64 characters, catching adapters that accidentally pass MD5 or truncated hashes
- **`escapeJson()` completed**: added `\t`, `\b`, `\f` escape sequences to the private helper

All test fixtures using short fingerprint literals (`"test-fingerprint"`, `"default-fingerprint"`, `"sha256-*"`) updated to 64-character values. New `IdempotencyContextTest` added.

## Test plan

- [ ] `mvn test -pl idempotency-core,idempotency-test,providers/idempotency-inmemory,spring/idempotency-spring-web -am` passes (all 124 tests)
- [ ] Spotless formatting applied with no remaining violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)