### PR TITLE
Add ResponseSanitizer SPI to control what is persisted before storage

### DIFF
--- a/idempotency-core/src/main/java/io/github/josipmusa/core/ResponseSanitizer.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/ResponseSanitizer.java
@@ -1,0 +1,38 @@
+package io.github.josipmusa.core;
+
+/**
+ * SPI for sanitizing {@link StoredResponse} instances before they are persisted.
+ *
+ * <p>Called by the adapter layer (e.g. {@code IdempotencyFilter}) immediately
+ * before {@link IdempotencyStore#complete}. The returned value is what gets
+ * stored and replayed on duplicate requests.
+ *
+ * <p>The default (registered by the Spring Boot starter) is an identity —
+ * no sanitization. Override this bean to strip sensitive headers or mask
+ * the response body:
+ *
+ * <pre>{@code
+ * @Bean
+ * ResponseSanitizer responseSanitizer() {
+ *     return response -> new StoredResponse(
+ *         response.statusCode(),
+ *         response.headers().entrySet().stream()
+ *             .filter(e -> !e.getKey().equalsIgnoreCase("Set-Cookie"))
+ *             .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue)),
+ *         response.body(),
+ *         response.completedAt()
+ *     );
+ * }
+ * }</pre>
+ */
+@FunctionalInterface
+public interface ResponseSanitizer {
+
+    /**
+     * Sanitizes the given response before storage.
+     *
+     * @param response the captured response; never {@code null}
+     * @return the sanitized response to store; must not be {@code null}
+     */
+    StoredResponse sanitize(StoredResponse response);
+}

--- a/idempotency-core/src/main/java/io/github/josipmusa/core/ResponseSanitizer.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/ResponseSanitizer.java
@@ -7,23 +7,6 @@ package io.github.josipmusa.core;
  * before {@link IdempotencyStore#complete}. The returned value is what gets
  * stored and replayed on duplicate requests.
  *
- * <p>The default (registered by the Spring Boot starter) is an identity —
- * no sanitization. Override this bean to strip sensitive headers or mask
- * the response body:
- *
- * <pre>{@code
- * @Bean
- * ResponseSanitizer responseSanitizer() {
- *     return response -> new StoredResponse(
- *         response.statusCode(),
- *         response.headers().entrySet().stream()
- *             .filter(e -> !e.getKey().equalsIgnoreCase("Set-Cookie"))
- *             .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue)),
- *         response.body(),
- *         response.completedAt()
- *     );
- * }
- * }</pre>
  */
 @FunctionalInterface
 public interface ResponseSanitizer {

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfiguration.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfiguration.java
@@ -3,6 +3,7 @@ package io.github.josipmusa.idempotency.springboot;
 import io.github.josipmusa.core.IdempotencyConfig;
 import io.github.josipmusa.core.IdempotencyEngine;
 import io.github.josipmusa.core.IdempotencyStore;
+import io.github.josipmusa.core.ResponseSanitizer;
 import io.github.josipmusa.idempotency.spring.web.IdempotencyFilter;
 import io.github.josipmusa.idempotency.spring.web.IdempotentHandlerRegistry;
 import java.util.concurrent.Executors;
@@ -32,6 +33,12 @@ public class IdempotencyAutoConfiguration {
                 .defaultTtl(idempotencyProperties.getDefaultTtl())
                 .defaultLockTimeout(idempotencyProperties.getDefaultLockTimeout())
                 .build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    ResponseSanitizer responseSanitizer() {
+        return response -> response;
     }
 
     @Bean(destroyMethod = "shutdownNow")
@@ -70,8 +77,10 @@ public class IdempotencyAutoConfiguration {
             IdempotencyConfig config,
             RequestMappingHandlerMapping handlerMapping,
             IdempotentHandlerRegistry registry,
-            IdempotencyProperties properties) {
-        return new IdempotencyFilter(engine, store, config, handlerMapping, registry, properties.getMaxBodyBytes());
+            IdempotencyProperties properties,
+            ResponseSanitizer sanitizer) {
+        return new IdempotencyFilter(
+                engine, store, config, handlerMapping, registry, properties.getMaxBodyBytes(), sanitizer);
     }
 
     @Bean

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import io.github.josipmusa.core.IdempotencyConfig;
 import io.github.josipmusa.core.IdempotencyEngine;
 import io.github.josipmusa.core.IdempotencyStore;
+import io.github.josipmusa.core.ResponseSanitizer;
 import io.github.josipmusa.idempotency.spring.web.IdempotencyFilter;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
@@ -140,18 +141,18 @@ class IdempotencyAutoConfigurationTest {
     @Test
     void When_NoCustomSanitizerBean_Expect_DefaultSanitizerRegistered() {
         contextRunner.run(context -> {
-            assertThat(context).hasSingleBean(io.github.josipmusa.core.ResponseSanitizer.class);
+            assertThat(context).hasSingleBean(ResponseSanitizer.class);
         });
     }
 
     @Test
     void When_CustomSanitizerBean_Expect_AutoConfiguredSanitizerSkipped() {
-        io.github.josipmusa.core.ResponseSanitizer custom = response -> response;
+        ResponseSanitizer custom = response -> response;
         contextRunner
-                .withBean(io.github.josipmusa.core.ResponseSanitizer.class, () -> custom)
+                .withBean(ResponseSanitizer.class, () -> custom)
                 .run(context -> {
-                    assertThat(context).hasSingleBean(io.github.josipmusa.core.ResponseSanitizer.class);
-                    assertThat(context.getBean(io.github.josipmusa.core.ResponseSanitizer.class))
+                    assertThat(context).hasSingleBean(ResponseSanitizer.class);
+                    assertThat(context.getBean(ResponseSanitizer.class))
                             .isSameAs(custom);
                 });
     }

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
@@ -148,12 +148,9 @@ class IdempotencyAutoConfigurationTest {
     @Test
     void When_CustomSanitizerBean_Expect_AutoConfiguredSanitizerSkipped() {
         ResponseSanitizer custom = response -> response;
-        contextRunner
-                .withBean(ResponseSanitizer.class, () -> custom)
-                .run(context -> {
-                    assertThat(context).hasSingleBean(ResponseSanitizer.class);
-                    assertThat(context.getBean(ResponseSanitizer.class))
-                            .isSameAs(custom);
-                });
+        contextRunner.withBean(ResponseSanitizer.class, () -> custom).run(context -> {
+            assertThat(context).hasSingleBean(ResponseSanitizer.class);
+            assertThat(context.getBean(ResponseSanitizer.class)).isSameAs(custom);
+        });
     }
 }

--- a/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
+++ b/spring/idempotency-spring-boot-starter/src/test/java/io/github/josipmusa/idempotency/springboot/IdempotencyAutoConfigurationTest.java
@@ -136,4 +136,23 @@ class IdempotencyAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(IdempotencyConfig.class);
                 });
     }
+
+    @Test
+    void When_NoCustomSanitizerBean_Expect_DefaultSanitizerRegistered() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(io.github.josipmusa.core.ResponseSanitizer.class);
+        });
+    }
+
+    @Test
+    void When_CustomSanitizerBean_Expect_AutoConfiguredSanitizerSkipped() {
+        io.github.josipmusa.core.ResponseSanitizer custom = response -> response;
+        contextRunner
+                .withBean(io.github.josipmusa.core.ResponseSanitizer.class, () -> custom)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(io.github.josipmusa.core.ResponseSanitizer.class);
+                    assertThat(context.getBean(io.github.josipmusa.core.ResponseSanitizer.class))
+                            .isSameAs(custom);
+                });
+    }
 }

--- a/spring/idempotency-spring-web/src/main/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilter.java
+++ b/spring/idempotency-spring-web/src/main/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilter.java
@@ -7,6 +7,7 @@ import io.github.josipmusa.core.IdempotencyConfig;
 import io.github.josipmusa.core.IdempotencyContext;
 import io.github.josipmusa.core.IdempotencyEngine;
 import io.github.josipmusa.core.IdempotencyStore;
+import io.github.josipmusa.core.ResponseSanitizer;
 import io.github.josipmusa.core.StoredResponse;
 import io.github.josipmusa.core.exception.IdempotencyFingerprintMismatchException;
 import io.github.josipmusa.core.exception.IdempotencyLockTimeoutException;
@@ -59,6 +60,24 @@ public class IdempotencyFilter extends OncePerRequestFilter {
     private final RequestMappingHandlerMapping handlerMapping;
     private final IdempotentHandlerRegistry registry;
     private final long maxBodyBytes;
+    private final ResponseSanitizer sanitizer;
+
+    public IdempotencyFilter(
+            IdempotencyEngine engine,
+            IdempotencyStore store,
+            IdempotencyConfig config,
+            RequestMappingHandlerMapping handlerMapping,
+            IdempotentHandlerRegistry registry,
+            long maxBodyBytes,
+            ResponseSanitizer sanitizer) {
+        this.engine = Objects.requireNonNull(engine, "engine must not be null");
+        this.store = Objects.requireNonNull(store, "store must not be null");
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.handlerMapping = Objects.requireNonNull(handlerMapping, "handlerMapping must not be null");
+        this.registry = Objects.requireNonNull(registry, "registry must not be null");
+        this.maxBodyBytes = maxBodyBytes;
+        this.sanitizer = Objects.requireNonNull(sanitizer, "sanitizer must not be null");
+    }
 
     public IdempotencyFilter(
             IdempotencyEngine engine,
@@ -67,12 +86,7 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             RequestMappingHandlerMapping handlerMapping,
             IdempotentHandlerRegistry registry,
             long maxBodyBytes) {
-        this.engine = Objects.requireNonNull(engine, "engine must not be null");
-        this.store = Objects.requireNonNull(store, "store must not be null");
-        this.config = Objects.requireNonNull(config, "config must not be null");
-        this.handlerMapping = Objects.requireNonNull(handlerMapping, "handlerMapping must not be null");
-        this.registry = Objects.requireNonNull(registry, "registry must not be null");
-        this.maxBodyBytes = maxBodyBytes;
+        this(engine, store, config, handlerMapping, registry, maxBodyBytes, response -> response);
     }
 
     public IdempotencyFilter(
@@ -81,7 +95,7 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             IdempotencyConfig config,
             RequestMappingHandlerMapping handlerMapping,
             IdempotentHandlerRegistry registry) {
-        this(engine, store, config, handlerMapping, registry, NO_LIMIT);
+        this(engine, store, config, handlerMapping, registry, NO_LIMIT, response -> response);
     }
 
     @Override
@@ -156,8 +170,9 @@ public class IdempotencyFilter extends OncePerRequestFilter {
                         collectHeaders(wrappedResponse),
                         wrappedResponse.getContentAsByteArray(),
                         Instant.now());
+                StoredResponse sanitized = sanitizer.sanitize(storedResponse);
                 try {
-                    store.complete(context.key(), storedResponse, context.ttl());
+                    store.complete(context.key(), sanitized, context.ttl());
                 } catch (Exception e) {
                     log.error(
                             "Failed to store idempotency response for key '"

--- a/spring/idempotency-spring-web/src/test/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilterTest.java
+++ b/spring/idempotency-spring-web/src/test/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import io.github.josipmusa.core.*;
+import io.github.josipmusa.core.ResponseSanitizer;
 import io.github.josipmusa.core.exception.IdempotencyFingerprintMismatchException;
 import io.github.josipmusa.core.exception.IdempotencyLockTimeoutException;
 import jakarta.servlet.FilterChain;
@@ -399,6 +400,49 @@ class IdempotencyFilterTest {
 
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.getHeader("Idempotent-Replayed")).isEqualTo("true");
+    }
+
+    @Test
+    void When_SanitizerConfigured_Expect_SanitizedResponseStoredNotOriginal() throws Exception {
+        setupAnnotatedHandler(AnnotationHelper.annotation(true));
+        request.addHeader("Idempotency-Key", "test-key");
+
+        ResponseSanitizer sanitizer = response -> new StoredResponse(
+                response.statusCode(),
+                response.headers().entrySet().stream()
+                        .filter(e -> !e.getKey().equalsIgnoreCase("X-Secret"))
+                        .collect(java.util.stream.Collectors.toUnmodifiableMap(
+                                Map.Entry::getKey, Map.Entry::getValue)),
+                response.body(),
+                response.completedAt());
+
+        IdempotencyFilter filterWithSanitizer = new IdempotencyFilter(
+                engine, store, IdempotencyConfig.defaults(), handlerMapping, registry, -1L, sanitizer);
+
+        doAnswer(invocation -> {
+                    ThrowingRunnable action = invocation.getArgument(1);
+                    action.run();
+                    return ExecutionResult.executed();
+                })
+                .when(engine)
+                .execute(any(), any());
+
+        doAnswer(invocation -> {
+                    HttpServletResponse resp = invocation.getArgument(1);
+                    resp.setStatus(200);
+                    resp.setContentType("application/json");
+                    resp.addHeader("X-Secret", "token-abc");
+                    resp.getWriter().write("{\"id\":\"1\"}");
+                    return null;
+                })
+                .when(filterChain)
+                .doFilter(any(), any());
+
+        filterWithSanitizer.doFilter(request, response, filterChain);
+
+        var captor = org.mockito.ArgumentCaptor.forClass(StoredResponse.class);
+        verify(store).complete(eq("test-key"), captor.capture(), any(Duration.class));
+        assertThat(captor.getValue().headers()).doesNotContainKey("X-Secret");
     }
 
     private void setupAnnotatedHandler(Idempotent annotation) throws Exception {

--- a/spring/idempotency-spring-web/src/test/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilterTest.java
+++ b/spring/idempotency-spring-web/src/test/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilterTest.java
@@ -410,8 +410,7 @@ class IdempotencyFilterTest {
                 response.statusCode(),
                 response.headers().entrySet().stream()
                         .filter(e -> !e.getKey().equalsIgnoreCase("X-Secret"))
-                        .collect(java.util.stream.Collectors.toUnmodifiableMap(
-                                Map.Entry::getKey, Map.Entry::getValue)),
+                        .collect(java.util.stream.Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue)),
                 response.body(),
                 response.completedAt());
 

--- a/spring/idempotency-spring-web/src/test/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilterTest.java
+++ b/spring/idempotency-spring-web/src/test/java/io/github/josipmusa/idempotency/spring/web/IdempotencyFilterTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import io.github.josipmusa.core.*;
-import io.github.josipmusa.core.ResponseSanitizer;
 import io.github.josipmusa.core.exception.IdempotencyFingerprintMismatchException;
 import io.github.josipmusa.core.exception.IdempotencyLockTimeoutException;
 import jakarta.servlet.FilterChain;


### PR DESCRIPTION
## Summary

- Adds `ResponseSanitizer` functional interface to `idempotency-core` — a pure Java SPI that allows callers to sanitize a `StoredResponse` before it is persisted to the store
- Wires it into `IdempotencyFilter`: the sanitized result (not the original) is passed to `store.complete()` in the `Executed` branch; existing constructors default to identity
- Registers a no-op default bean in `IdempotencyAutoConfiguration` with `@ConditionalOnMissingBean`, so users override with a single `@Bean` declaration

## Test Plan

- [ ] `When_SanitizerConfigured_Expect_SanitizedResponseStoredNotOriginal` — verifies sanitizer is called and its output is what reaches the store
- [ ] `When_NoCustomSanitizerBean_Expect_DefaultSanitizerRegistered` — verifies default identity bean is auto-configured
- [ ] `When_CustomSanitizerBean_Expect_AutoConfiguredSanitizerSkipped` — verifies user-supplied bean takes precedence
- [ ] `mvn verify` — full suite green across all modules

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)