### PR TITLE
Prepare project for open-source release

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening a GitHub issue or contacting the maintainers directly. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing
+
+## Building the project
+
+Requires Java 21 and Maven 3.9+.
+
+```bash
+mvn verify
+```
+
+This compiles everything, runs all tests, and checks formatting. A clean build is the baseline for any contribution.
+
+To build a single module without running the full suite:
+
+```bash
+mvn test -pl providers/idempotency-inmemory -am
+```
+
+The `-am` flag builds upstream dependencies from source so SNAPSHOT versions resolve correctly.
+
+## Running tests
+
+Unit and integration tests are in each module's `src/test/java`. Integration tests for JDBC backends use [Testcontainers](https://testcontainers.com/) — Docker must be running.
+
+```bash
+mvn test                    # all tests
+mvn test -pl idempotency-core   # core tests only
+```
+
+## Code style
+
+Formatting is enforced by [Spotless](https://github.com/diffplug/spotless) with [Palantir Java Format](https://github.com/palantir/palantir-java-format). The build fails on any formatting violation.
+
+To auto-fix before committing:
+
+```bash
+mvn spotless:apply
+```
+
+## Module boundaries
+
+These rules are enforced by design, not by tooling — violating them will be caught in review:
+
+- `idempotency-core` has zero framework dependencies.
+- `idempotency-jdbc` and `idempotency-inmemory` depend on core only — no Spring.
+- `idempotency-spring-web` depends on core + Spring Web.
+- `idempotency-spring-boot-starter` depends on the spring module + providers.
+
+If you find yourself adding a Spring dependency to core or a provider, stop — the design is wrong.
+
+## Adding a new store implementation
+
+1. Implement `IdempotencyStore` from `idempotency-core`.
+2. Extend `IdempotencyStoreContract` from `idempotency-test` and implement `store()`.
+3. The contract suite is the single source of truth for store behavior. All tests in it must pass.
+
+## Pull requests
+
+- One logical change per PR.
+- Include a test that fails before your change and passes after, unless the change is documentation-only.
+- Match existing test naming: `When_<Context>_Expect_<Result>`.
+- Keep commit messages short and factual — one sentence per logical change.
+
+Before opening a PR, run:
+
+```bash
+mvn verify
+```
+
+If it passes locally, it will pass in CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,21 +10,22 @@ mvn verify
 
 This compiles everything, runs all tests, and checks formatting. A clean build is the baseline for any contribution.
 
-To build a single module without running the full suite:
+To test a specific module without running the full suite, always use `-pl` and `-am`:
 
 ```bash
-mvn test -pl providers/idempotency-inmemory -am
+mvn test -pl idempotency-core -am
+mvn test -pl providers/idempotency-jdbc -am
 ```
 
 The `-am` flag builds upstream dependencies from source so SNAPSHOT versions resolve correctly.
 
 ## Running tests
 
-Unit and integration tests are in each module's `src/test/java`. Integration tests for JDBC backends use [Testcontainers](https://testcontainers.com/) — Docker must be running.
+Unit and integration tests are in each module's `src/test/java`. Provider modules that require infrastructure use [Testcontainers](https://testcontainers.com/) — Docker must be running when testing those.
 
 ```bash
-mvn test                    # all tests
-mvn test -pl idempotency-core   # core tests only
+mvn test              # all tests
+mvn test -pl idempotency-core -am   # core tests only
 ```
 
 ## Code style

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,192 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other transformations
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as authored or submitted to the Licensor
+      for inclusion in the Work by the copyright owner or by an individual
+      or Legal Entity authorized to submit on behalf of the copyright owner.
+      For the purposes of this definition, "submitted" means any form of
+      electronic, verbal, or written communication sent to the Licensor or
+      its representatives, including but not limited to communication on
+      electronic mailing lists, source code control systems, and issue
+      tracking systems that are managed by, or on behalf of, the Licensor
+      for the purpose of discussing and improving the Work, but excluding
+      communication that is conspicuously marked or designated in writing
+      by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Derivative Works, as a whole or in part.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a result
+      of this License or out of the use or inability to use the Work
+      (including but not limited to damages for loss of goodwill, work
+      stoppage, computer failure or malfunction, or all other commercial
+      damages or losses), even if such Contributor has been advised of the
+      possibility of such damages.
+
+   9. Accepting Warranty or Liability. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may offer such obligations only on
+      Your own behalf and on Your sole responsibility, not on behalf of
+      any other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the format in question. Please include a
+      NOTICE file as well, if applicable.
+
+   Copyright 2024 Josip Musa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -177,7 +177,7 @@
       comment syntax for the format in question. Please include a
       NOTICE file as well, if applicable.
 
-   Copyright 2024 Josip Musa
+   Copyright 2026 Josip Musa
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
 # idempotency4j
 
-A Java library that adds idempotency to Spring Boot APIs. Send the same request twice — get the same response, side effects run exactly once.
+A Java idempotency library with pluggable storage backends and Spring Web / Spring Boot support.
 
-Built around a clean separation between the orchestration engine, the persistence store, and the framework adapter. The engine knows nothing about HTTP or databases; the store knows nothing about Spring; the adapter knows nothing about lock lifecycles.
+Send the same request twice — get the same response, side effects run exactly once.
 
 ## When to use this
 
 Your API needs idempotency if clients can retry on network failure (payment processing, order creation, resource provisioning) and a duplicated request would cause a real problem — money charged twice, two orders shipped, two VMs started.
 
-The alternative is building idempotency ad-hoc per endpoint. This library gives you that as infrastructure.
-
 ## Quick start
 
-Add the Spring Boot starter and a storage backend to your project:
+Add the Spring Boot starter and a storage backend:
 
 ```xml
 <dependency>
@@ -51,7 +49,7 @@ Annotate the endpoints that need idempotency:
 @PostMapping("/payments")
 @Idempotent
 public ResponseEntity<Payment> createPayment(@RequestBody PaymentRequest request) {
-    // Runs exactly once per unique Idempotency-Key header value.
+    // Runs exactly once per unique Idempotency-Key value.
     // Subsequent identical requests get the stored response replayed.
     return ResponseEntity.ok(paymentService.charge(request));
 }
@@ -67,7 +65,7 @@ Content-Type: application/json
 { "amount": 100, "currency": "USD" }
 ```
 
-If that key has been used before with the same request body, the stored response is returned with `Idempotent-Replayed: true`. If the same key arrives with a different body, the request is rejected with `422 Unprocessable Entity`.
+If that key has been seen before with the same request body, the stored response is returned with `Idempotent-Replayed: true`. If the same key arrives with a different body, the request is rejected with `422 Unprocessable Entity`.
 
 ## The `@Idempotent` annotation
 
@@ -83,7 +81,7 @@ If that key has been used before with the same request body, the stored response
 
 | Key header present | Behavior |
 |--------------------|----------|
-| Yes                | Full idempotency enforcement — same as `required = true` |
+| Yes                | Full idempotency enforcement |
 | No                 | Request passes through unmodified, no idempotency enforced |
 
 Use `required = false` on endpoints where idempotency is optional — clients that care send a key, clients that do not are not rejected.
@@ -92,25 +90,8 @@ Use `required = false` on endpoints where idempotency is optional — clients th
 
 | Module | Use when |
 |--------|----------|
-| `idempotency-jdbc` | You have a relational database. Tested with MySQL and PostgreSQL. |
-| `idempotency-inmemory` | Single-instance deployments, local development, tests. Not suitable for horizontally-scaled environments. |
-
-For JDBC, the store needs a table. Run this migration before starting the application:
-
-```sql
-CREATE TABLE idempotency_records (
-    idempotency_key   VARCHAR(255)  NOT NULL,
-    status            VARCHAR(20)   NOT NULL,
-    request_fingerprint VARCHAR(64),
-    response_status   INT,
-    response_headers  TEXT,
-    response_body     MEDIUMBLOB,
-    created_at        DATETIME(3)   NOT NULL,
-    lock_expires_at   DATETIME(3),
-    expires_at        DATETIME(3),
-    PRIMARY KEY (idempotency_key)
-);
-```
+| `idempotency-jdbc` | You have a relational database. Supports MySQL and PostgreSQL. Schema is initialized automatically. |
+| `idempotency-inmemory` | Single-instance deployments, local development, and tests. Not suitable for horizontally-scaled environments. |
 
 ## Configuration
 
@@ -129,70 +110,28 @@ idempotency:
 
 Per-endpoint values in `@Idempotent` override these defaults.
 
-## How it works
-
-Three layers, each with one responsibility:
-
-**Engine** (`IdempotencyEngine`) — acquires the lock, runs the action, manages the heartbeat. Does not know about HTTP or databases.
-
-**Store** (`IdempotencyStore`) — handles persistence and in-flight blocking. `tryAcquire` is synchronous and fully resolved: the engine never polls. Implemented by the jdbc/inmemory modules.
-
-**Adapter** (`IdempotencyFilter`) — translates the HTTP request into an `IdempotencyContext`, calls the engine, stores the response on completion, and replays it on duplicates.
-
-### Key lifecycle
-
-```
-[not exists] ──tryAcquire──> IN_PROGRESS ──complete()──> COMPLETE
-                                  │
-                              release()   (action failed)
-                                  │
-                                  v
-                               FAILED ──tryAcquire──> IN_PROGRESS
-```
-
-`COMPLETE` keys return the stored response on all subsequent requests until TTL expires. `IN_PROGRESS` keys whose lock has expired are stealable by the next caller (handles crashes).
-
-### Request fingerprinting
-
-Every request body is hashed (SHA-256) and stored alongside the key. A second request with the same key but a different body hash is rejected with `422` — it is a different operation, not a retry.
-
-### Expiry and purging
-
-The starter registers a scheduled task that calls `purgeExpired()` on the store using the cron expression from `idempotency.purge.cron`. The task only runs if `@EnableScheduling` is present. If you are not using the starter, call `purgeExpired()` yourself from a `ScheduledExecutorService`.
-
-## Implementing a custom store
-
-Implement `IdempotencyStore` from `idempotency-core`:
-
-```java
-public interface IdempotencyStore {
-    AcquireResult tryAcquire(IdempotencyContext context);
-    void complete(String key, StoredResponse response, Duration ttl);
-    void release(String key);
-    void extendLock(String key, Duration extension);
-    int purgeExpired();
-}
-```
-
-Extend `IdempotencyStoreContract` from `idempotency-test` — that contract test suite verifies all behavioral requirements including lock stealing, fingerprint mismatches, and concurrent access.
-
-```java
-class MyStoreTest extends IdempotencyStoreContract {
-    @Override
-    protected IdempotencyStore store() {
-        return new MyIdempotencyStore(...);
-    }
-}
-```
-
 ## Security considerations
 
 The store persists full HTTP response bodies. Depending on your endpoints this may include PII, tokens, or financial data.
 
 - Enable encryption at rest on the backing database.
-- Use short TTL values to limit retention.
+- Use short TTL values to limit data retention.
 - Configure `idempotency.purge.cron` to remove expired records promptly.
 - Audit which endpoints are annotated `@Idempotent` and what their responses contain.
+
+To strip or redact sensitive fields before storage, register a `ResponseSanitizer` bean. The default implementation is a no-op pass-through:
+
+```java
+@Bean
+public ResponseSanitizer responseSanitizer() {
+    return response -> {
+        // Remove sensitive headers, redact body, etc.
+        Map<String, List<String>> headers = new HashMap<>(response.headers());
+        headers.remove("Set-Cookie");
+        return new StoredResponse(response.statusCode(), headers, response.body(), response.storedAt());
+    };
+}
+```
 
 For vulnerability reporting, see [SECURITY.md](SECURITY.md).
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,201 @@
+# idempotency4j
+
+A Java library that adds idempotency to Spring Boot APIs. Send the same request twice — get the same response, side effects run exactly once.
+
+Built around a clean separation between the orchestration engine, the persistence store, and the framework adapter. The engine knows nothing about HTTP or databases; the store knows nothing about Spring; the adapter knows nothing about lock lifecycles.
+
+## When to use this
+
+Your API needs idempotency if clients can retry on network failure (payment processing, order creation, resource provisioning) and a duplicated request would cause a real problem — money charged twice, two orders shipped, two VMs started.
+
+The alternative is building idempotency ad-hoc per endpoint. This library gives you that as infrastructure.
+
+## Quick start
+
+Add the Spring Boot starter and a storage backend to your project:
+
+```xml
+<dependency>
+    <groupId>io.github.josipmusa</groupId>
+    <artifactId>idempotency-spring-boot-starter</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+</dependency>
+
+<!-- Pick one storage backend -->
+<dependency>
+    <groupId>io.github.josipmusa</groupId>
+    <artifactId>idempotency-jdbc</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+</dependency>
+```
+
+Or use the BOM to align all module versions:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.josipmusa</groupId>
+            <artifactId>idempotency-bom</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+Annotate the endpoints that need idempotency:
+
+```java
+@PostMapping("/payments")
+@Idempotent
+public ResponseEntity<Payment> createPayment(@RequestBody PaymentRequest request) {
+    // Runs exactly once per unique Idempotency-Key header value.
+    // Subsequent identical requests get the stored response replayed.
+    return ResponseEntity.ok(paymentService.charge(request));
+}
+```
+
+Clients pass a client-generated key with each request:
+
+```
+POST /payments
+Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000
+Content-Type: application/json
+
+{ "amount": 100, "currency": "USD" }
+```
+
+If that key has been used before with the same request body, the stored response is returned with `Idempotent-Replayed: true`. If the same key arrives with a different body, the request is rejected with `422 Unprocessable Entity`.
+
+## The `@Idempotent` annotation
+
+```java
+@Idempotent(
+    ttl = "PT24H",          // How long to keep the stored response (ISO-8601). Default: 24h
+    lockTimeout = "PT10S",  // How long a concurrent duplicate waits. Default: 10s
+    required = true         // Whether a missing key header is an error. Default: true
+)
+```
+
+### Behavior when `required = false`
+
+| Key header present | Behavior |
+|--------------------|----------|
+| Yes                | Full idempotency enforcement — same as `required = true` |
+| No                 | Request passes through unmodified, no idempotency enforced |
+
+Use `required = false` on endpoints where idempotency is optional — clients that care send a key, clients that do not are not rejected.
+
+## Storage backends
+
+| Module | Use when |
+|--------|----------|
+| `idempotency-jdbc` | You have a relational database. Tested with MySQL and PostgreSQL. |
+| `idempotency-inmemory` | Single-instance deployments, local development, tests. Not suitable for horizontally-scaled environments. |
+
+For JDBC, the store needs a table. Run this migration before starting the application:
+
+```sql
+CREATE TABLE idempotency_records (
+    idempotency_key   VARCHAR(255)  NOT NULL,
+    status            VARCHAR(20)   NOT NULL,
+    request_fingerprint VARCHAR(64),
+    response_status   INT,
+    response_headers  TEXT,
+    response_body     MEDIUMBLOB,
+    created_at        DATETIME(3)   NOT NULL,
+    lock_expires_at   DATETIME(3),
+    expires_at        DATETIME(3),
+    PRIMARY KEY (idempotency_key)
+);
+```
+
+## Configuration
+
+All properties are prefixed with `idempotency`:
+
+```yaml
+idempotency:
+  key-header: Idempotency-Key     # Header name carrying the key. Default: Idempotency-Key
+  default-ttl: PT24H              # Default TTL for stored responses. Default: 24h
+  default-lock-timeout: PT10S     # Default lock timeout. Default: 10s
+  key-required: true              # Global default for @Idempotent(required). Default: true
+  max-body-bytes: -1              # Max request body size to fingerprint (-1 = unlimited). Default: -1
+  purge:
+    cron: "0 0 * * * *"          # Cron expression for purging expired records. Default: hourly
+```
+
+Per-endpoint values in `@Idempotent` override these defaults.
+
+## How it works
+
+Three layers, each with one responsibility:
+
+**Engine** (`IdempotencyEngine`) — acquires the lock, runs the action, manages the heartbeat. Does not know about HTTP or databases.
+
+**Store** (`IdempotencyStore`) — handles persistence and in-flight blocking. `tryAcquire` is synchronous and fully resolved: the engine never polls. Implemented by the jdbc/inmemory modules.
+
+**Adapter** (`IdempotencyFilter`) — translates the HTTP request into an `IdempotencyContext`, calls the engine, stores the response on completion, and replays it on duplicates.
+
+### Key lifecycle
+
+```
+[not exists] ──tryAcquire──> IN_PROGRESS ──complete()──> COMPLETE
+                                  │
+                              release()   (action failed)
+                                  │
+                                  v
+                               FAILED ──tryAcquire──> IN_PROGRESS
+```
+
+`COMPLETE` keys return the stored response on all subsequent requests until TTL expires. `IN_PROGRESS` keys whose lock has expired are stealable by the next caller (handles crashes).
+
+### Request fingerprinting
+
+Every request body is hashed (SHA-256) and stored alongside the key. A second request with the same key but a different body hash is rejected with `422` — it is a different operation, not a retry.
+
+### Expiry and purging
+
+The starter registers a scheduled task that calls `purgeExpired()` on the store using the cron expression from `idempotency.purge.cron`. The task only runs if `@EnableScheduling` is present. If you are not using the starter, call `purgeExpired()` yourself from a `ScheduledExecutorService`.
+
+## Implementing a custom store
+
+Implement `IdempotencyStore` from `idempotency-core`:
+
+```java
+public interface IdempotencyStore {
+    AcquireResult tryAcquire(IdempotencyContext context);
+    void complete(String key, StoredResponse response, Duration ttl);
+    void release(String key);
+    void extendLock(String key, Duration extension);
+    int purgeExpired();
+}
+```
+
+Extend `IdempotencyStoreContract` from `idempotency-test` — that contract test suite verifies all behavioral requirements including lock stealing, fingerprint mismatches, and concurrent access.
+
+```java
+class MyStoreTest extends IdempotencyStoreContract {
+    @Override
+    protected IdempotencyStore store() {
+        return new MyIdempotencyStore(...);
+    }
+}
+```
+
+## Security considerations
+
+The store persists full HTTP response bodies. Depending on your endpoints this may include PII, tokens, or financial data.
+
+- Enable encryption at rest on the backing database.
+- Use short TTL values to limit retention.
+- Configure `idempotency.purge.cron` to remove expired records promptly.
+- Audit which endpoints are annotated `@Idempotent` and what their responses contain.
+
+For vulnerability reporting, see [SECURITY.md](SECURITY.md).
+
+## License
+
+Apache 2.0. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,10 @@ Include as much of the following as you can:
 
 You will receive a response within 7 days. If you do not hear back, follow up on the advisory thread.
 
+## Reducing sensitive data exposure
+
+The store persists full HTTP response bodies. To strip or redact sensitive fields before they are written to the store, register a `ResponseSanitizer` bean. The Spring Boot starter picks it up automatically and calls it on every response before storage. See the README for an example.
+
 ## Scope
 
 This library persists full HTTP response bodies, which may include sensitive data depending on which endpoints are annotated with `@Idempotent`. Key areas to consider when assessing impact:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Report vulnerabilities by opening a [GitHub Security Advisory](https://github.com/josipmusa/idempotency4j/security/advisories/new). This keeps the details private until a fix is available.
+
+Include as much of the following as you can:
+
+- A description of the vulnerability and its potential impact
+- The affected module(s) and version(s)
+- Steps to reproduce or a proof-of-concept
+- Any suggested mitigations
+
+You will receive a response within 7 days. If you do not hear back, follow up on the advisory thread.
+
+## Scope
+
+This library persists full HTTP response bodies, which may include sensitive data depending on which endpoints are annotated with `@Idempotent`. Key areas to consider when assessing impact:
+
+- The contents of stored responses (PII, tokens, financial data)
+- The idempotency key header value used as a map key in the store
+- The request fingerprint (SHA-256 of the request body)
+
+## Out of scope
+
+- Vulnerabilities in third-party dependencies (report those to the respective projects)
+- Issues that require physical access to the server or database

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,33 @@
     <artifactId>idempotency4j</artifactId>
     <packaging>pom</packaging>
     <version>0.0.1-SNAPSHOT</version>
+    <name>idempotency4j</name>
     <description>Idempotency Java Library</description>
+    <url>https://github.com/josipmusa/idempotency4j</url>
+    <inceptionYear>2024</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>josipmusa</id>
+            <name>Josip Musa</name>
+            <url>https://github.com/josipmusa</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/josipmusa/idempotency4j.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/josipmusa/idempotency4j.git</developerConnection>
+        <url>https://github.com/josipmusa/idempotency4j</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <modules>
         <module>idempotency-bom</module>
@@ -34,6 +60,10 @@
         <testcontainers-postgresql.version>1.20.4</testcontainers-postgresql.version>
         <testcontainers-junit-jupiter.version>1.20.4</testcontainers-junit-jupiter.version>
         <jackson.version>2.18.2</jackson.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
+        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -147,5 +177,83 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!--
+            Release profile: activated with -Prelease.
+            Generates sources and Javadoc JARs, signs all artifacts, and publishes
+            to Maven Central via the Sonatype Central Publishing plugin.
+
+            Prerequisites:
+              - GPG key available to the build agent
+              - CENTRAL_USERNAME / CENTRAL_TOKEN environment variables (or in settings.xml)
+
+            To publish a release:
+              mvn versions:set -DnewVersion=X.Y.Z
+              mvn deploy -Prelease
+        -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <configuration>
+                            <release>${java.version}</release>
+                            <doclint>all,-missing</doclint>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <name>idempotency4j</name>
     <description>Idempotency Java Library</description>
     <url>https://github.com/josipmusa/idempotency4j</url>
-    <inceptionYear>2024</inceptionYear>
+    <inceptionYear>2026</inceptionYear>
 
     <licenses>
         <license>

--- a/spring/idempotency-spring-web/src/main/java/io/github/josipmusa/idempotency/spring/web/Idempotent.java
+++ b/spring/idempotency-spring-web/src/main/java/io/github/josipmusa/idempotency/spring/web/Idempotent.java
@@ -34,7 +34,19 @@ public @interface Idempotent {
 
     /**
      * Whether a missing idempotency key header should be rejected with 422 Unprocessable Entity.
-     * When false, requests without a key pass through without idempotency enforcement.
+     *
+     * <p>Full behavior matrix:
+     * <table>
+     *   <caption>required vs key presence</caption>
+     *   <tr><th>required</th><th>Key header present</th><th>Behavior</th></tr>
+     *   <tr><td>true (default)</td><td>Yes</td><td>Full idempotency enforcement</td></tr>
+     *   <tr><td>true (default)</td><td>No</td><td>422 Unprocessable Entity</td></tr>
+     *   <tr><td>false</td><td>Yes</td><td>Full idempotency enforcement</td></tr>
+     *   <tr><td>false</td><td>No</td><td>Request passes through without idempotency enforcement</td></tr>
+     * </table>
+     *
+     * <p>Use {@code required = false} on endpoints where idempotency is optional —
+     * clients that want it send a key; clients that do not are not rejected.
      */
     boolean required() default true;
 }


### PR DESCRIPTION
## Summary

- Add Apache 2.0 `LICENSE` file
- Add `README.md` with quick start, behavior matrix, configuration reference, and store contract docs
- Add `CONTRIBUTING.md` covering build, tests, code style, module rules, and PR process
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1)
- Add `SECURITY.md` with responsible disclosure via GitHub Security Advisories
- Document the `@Idempotent(required=false)` behavior matrix in the annotation Javadoc
- Add required Maven Central POM metadata (`url`, `scm`, `licenses`, `developers`)
- Add `release` profile with `maven-source-plugin`, `maven-javadoc-plugin`, `maven-gpg-plugin`, and `central-publishing-maven-plugin`

## Release flow

The `release` profile is activated with `-Prelease`. No maven-release-plugin. To cut a release:

```bash
mvn versions:set -DnewVersion=X.Y.Z
mvn deploy -Prelease
```

Requires a GPG key and `CENTRAL_USERNAME`/`CENTRAL_TOKEN` credentials (via env or `settings.xml`).

## Test plan

- [x] `mvn verify` passes cleanly with all 7 issues addressed

Closes #27
Closes #28
Closes #31
Closes #53
Closes #54
Closes #55
Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)