### PR TITLE
Silence build warnings and add package-level Javadoc

### DIFF
--- a/idempotency-core/src/main/java/io/github/josipmusa/core/exception/package-info.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/exception/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Exception hierarchy for idempotency failures.
+ *
+ * <p>All exceptions are unchecked ({@link RuntimeException} subtypes) because
+ * idempotency failures are infrastructure errors that callers typically cannot
+ * recover from inline — they should propagate to the application's error handler.
+ *
+ * <ul>
+ *   <li>{@link io.github.josipmusa.core.exception.IdempotencyException} — base class
+ *       for all idempotency-related exceptions.</li>
+ *   <li>{@link io.github.josipmusa.core.exception.IdempotencyStoreException} — wraps
+ *       storage-level failures (database unreachable, serialization errors).</li>
+ *   <li>{@link io.github.josipmusa.core.exception.IdempotencyLockTimeoutException} —
+ *       thrown when a caller's {@code lockTimeout} expires while waiting for an
+ *       in-flight request to complete.</li>
+ *   <li>{@link io.github.josipmusa.core.exception.IdempotencyFingerprintMismatchException} —
+ *       thrown when the same idempotency key is reused with a different request body;
+ *       the adapter maps this to HTTP 422.</li>
+ * </ul>
+ */
+package io.github.josipmusa.core.exception;

--- a/idempotency-core/src/main/java/io/github/josipmusa/core/package-info.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/core/package-info.java
@@ -1,0 +1,29 @@
+/**
+ * Core idempotency engine and SPI interfaces.
+ *
+ * <p>This package contains the framework-agnostic heart of the library:
+ *
+ * <ul>
+ *   <li>{@link io.github.josipmusa.core.IdempotencyEngine} — orchestrates the
+ *       lock lifecycle and heartbeat; knows nothing about HTTP or databases.</li>
+ *   <li>{@link io.github.josipmusa.core.IdempotencyStore} — SPI for persistence
+ *       and in-flight coordination; implement this to add a new backend.</li>
+ *   <li>{@link io.github.josipmusa.core.IdempotencyContext} — fully resolved
+ *       request parameters passed to the engine; no nulls, no optionals.</li>
+ *   <li>{@link io.github.josipmusa.core.IdempotencyConfig} — configuration
+ *       defaults used by adapters to build an {@code IdempotencyContext}.</li>
+ *   <li>{@link io.github.josipmusa.core.AcquireResult} — sealed outcome of
+ *       {@code IdempotencyStore.tryAcquire}: {@code Acquired}, {@code Duplicate},
+ *       or {@code LockTimeout}.</li>
+ *   <li>{@link io.github.josipmusa.core.ExecutionResult} — sealed outcome of
+ *       {@code IdempotencyEngine.execute}: {@code Executed} or {@code Duplicate}.</li>
+ *   <li>{@link io.github.josipmusa.core.StoredResponse} — captured HTTP response
+ *       replayed to duplicate callers.</li>
+ *   <li>{@link io.github.josipmusa.core.ResponseSanitizer} — SPI for scrubbing
+ *       sensitive data from responses before they are persisted.</li>
+ * </ul>
+ *
+ * <p>This package has zero framework dependencies. Adding Spring, JDBC, or Redis
+ * imports here is a design error.
+ */
+package io.github.josipmusa.core;

--- a/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/package-info.java
+++ b/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Contract test suite for {@link io.github.josipmusa.core.IdempotencyStore} implementations.
+ *
+ * <p>{@link io.github.josipmusa.idempotency.test.IdempotencyStoreContract} is an abstract
+ * JUnit 5 test class that every {@code IdempotencyStore} implementation must extend.
+ * It is the single source of truth for store behavior — adding a case here automatically
+ * tests all implementations.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * class MyIdempotencyStoreTest extends IdempotencyStoreContract {
+ *     @Override
+ *     protected IdempotencyStore store() {
+ *         return new MyIdempotencyStore(...);
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>This artifact ships with {@code compile} scope for JUnit and AssertJ so that
+ * concrete test classes inherit those dependencies. Consumers should declare it with
+ * {@code <scope>test</scope>}.
+ */
+package io.github.josipmusa.idempotency.test;

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
-                        <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+                        <argLine>-XX:+EnableDynamicAgentLoading -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
                         <useModulePath>false</useModulePath>
                         <failIfNoTests>true</failIfNoTests>
                         <includes>

--- a/providers/idempotency-inmemory/src/main/java/io/github/josipmusa/idempotency/inmemory/package-info.java
+++ b/providers/idempotency-inmemory/src/main/java/io/github/josipmusa/idempotency/inmemory/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * In-memory {@link io.github.josipmusa.core.IdempotencyStore} implementation.
+ *
+ * <p>{@link io.github.josipmusa.idempotency.inmemory.InMemoryIdempotencyStore} is
+ * suitable for single-instance deployments and local development. It is not suitable
+ * for horizontally scaled environments — lock coordination and storage are
+ * per-JVM and are lost on restart.
+ *
+ * <p>This implementation is also the recommended test double when writing tests that
+ * need an {@code IdempotencyStore} without external infrastructure.
+ */
+package io.github.josipmusa.idempotency.inmemory;

--- a/providers/idempotency-jdbc/pom.xml
+++ b/providers/idempotency-jdbc/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStore.java
+++ b/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStore.java
@@ -34,8 +34,6 @@ import javax.sql.DataSource;
  * stealing and blocking. Compatible with any database that supports
  * row-level locking (MySQL, PostgreSQL, etc.).
  *
- * <p>Initializes schema by default</p>
- *
  * <p>No Spring dependencies — only requires a {@link DataSource}.
  *
  * <p><strong>Database compatibility:</strong> Automatically detects the database

--- a/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/package-info.java
+++ b/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * JDBC {@link io.github.josipmusa.core.IdempotencyStore} implementation.
+ *
+ * <p>{@link io.github.josipmusa.idempotency.jdbc.JdbcIdempotencyStore} stores
+ * idempotency records in a relational database using plain JDBC. It supports
+ * MySQL and PostgreSQL and has no dependency on Spring or any ORM.
+ *
+ * <p>The required schema is available in the {@code idempotency-schema-mysql.sql}
+ * and {@code idempotency-schema-postgresql.sql} resources bundled with this artifact.
+ * The store does not create the schema automatically — callers are responsible for
+ * applying the DDL before first use.
+ *
+ * <p>All lock coordination (blocking, lock stealing) is handled inside the store
+ * using database-level constructs. The engine never polls or waits externally.
+ */
+package io.github.josipmusa.idempotency.jdbc;

--- a/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/package-info.java
+++ b/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/package-info.java
@@ -5,10 +5,12 @@
  * idempotency records in a relational database using plain JDBC. It supports
  * MySQL and PostgreSQL and has no dependency on Spring or any ORM.
  *
- * <p>The required schema is available in the {@code idempotency-schema-mysql.sql}
- * and {@code idempotency-schema-postgresql.sql} resources bundled with this artifact.
- * The store does not create the schema automatically — callers are responsible for
- * applying the DDL before first use.
+ * <p>Schema initialization is enabled by default: the single-argument constructor
+ * {@code new JdbcIdempotencyStore(dataSource)} runs the DDL automatically on first use,
+ * detecting the database dialect from {@link java.sql.DatabaseMetaData#getDatabaseProductName()}
+ * and loading the appropriate bundled script ({@code idempotency-schema-mysql.sql} or
+ * {@code idempotency-schema-postgresql.sql}). To manage the schema externally (e.g. via
+ * Flyway or Liquibase), pass {@code initSchema = false} to the two-argument constructor.
  *
  * <p>All lock coordination (blocking, lock stealing) is handled inside the store
  * using database-level constructs. The engine never polls or waits externally.

--- a/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/package-info.java
+++ b/spring/idempotency-spring-boot-starter/src/main/java/io/github/josipmusa/idempotency/springboot/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Spring Boot autoconfiguration for idempotency4j.
+ *
+ * <p>This package wires all idempotency components together based on classpath detection.
+ * Applications should not reference these classes directly — they are activated
+ * automatically when the {@code idempotency-spring-boot-starter} artifact is on the
+ * classpath and an {@link io.github.josipmusa.core.IdempotencyStore} bean is present.
+ *
+ * <ul>
+ *   <li>{@link io.github.josipmusa.idempotency.springboot.IdempotencyAutoConfiguration} —
+ *       registers the engine, filter, handler registry, and scheduler beans.
+ *       All beans are conditional on {@code @ConditionalOnMissingBean} so applications
+ *       can override any individual component.</li>
+ *   <li>{@link io.github.josipmusa.idempotency.springboot.IdempotencyPurgeAutoConfiguration} —
+ *       registers a {@code SchedulingConfigurer} that schedules
+ *       {@link io.github.josipmusa.core.IdempotencyStore#purgeExpired()} using the cron
+ *       expression from {@code idempotency.purge-cron} (default: hourly). Inert if
+ *       {@code @EnableScheduling} is not present in the application context.</li>
+ *   <li>{@link io.github.josipmusa.idempotency.springboot.IdempotencyProperties} —
+ *       configuration properties bound from the {@code idempotency.*} namespace.</li>
+ * </ul>
+ */
+package io.github.josipmusa.idempotency.springboot;

--- a/spring/idempotency-spring-web/pom.xml
+++ b/spring/idempotency-spring-web/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/spring/idempotency-spring-web/src/main/java/io/github/josipmusa/idempotency/spring/web/package-info.java
+++ b/spring/idempotency-spring-web/src/main/java/io/github/josipmusa/idempotency/spring/web/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Spring MVC adapter for the idempotency engine.
+ *
+ * <p>This package bridges the idempotency core with HTTP. It contains:
+ *
+ * <ul>
+ *   <li>{@link io.github.josipmusa.idempotency.spring.web.Idempotent} — annotation
+ *       for marking controller methods that require idempotency enforcement.</li>
+ *   <li>{@link io.github.josipmusa.idempotency.spring.web.IdempotencyFilter} — servlet
+ *       filter that intercepts annotated requests, builds the
+ *       {@link io.github.josipmusa.core.IdempotencyContext}, invokes the engine,
+ *       captures the response, and calls {@code store.complete()}.</li>
+ *   <li>{@link io.github.josipmusa.idempotency.spring.web.IdempotentHandlerRegistry} —
+ *       inspects the {@link org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping}
+ *       at startup to determine which endpoints are annotated with {@code @Idempotent}.</li>
+ *   <li>{@link io.github.josipmusa.idempotency.spring.web.RequestFingerprint} — computes
+ *       a SHA-256 hex digest of the request body for fingerprint mismatch detection.</li>
+ * </ul>
+ *
+ * <p>The adapter is responsible for calling {@code store.complete()} after a successful
+ * action. The engine does not call {@code complete} — this boundary is intentional.
+ */
+package io.github.josipmusa.idempotency.spring.web;


### PR DESCRIPTION
## Summary

- **Mockito self-attach** — configured `mockito-core` as a proper `-javaagent` in surefire via `${settings.localRepository}` path; eliminates the "Mockito is currently self-attaching" warning across all modules without per-module configuration
- **SLF4J no-provider** — added `logback-classic` (test scope) to `idempotency-jdbc` and `idempotency-spring-web`, the two modules that bring SLF4J onto the test classpath without a binding
- **Package-level Javadoc** — added `package-info.java` to all seven main source packages, giving the generated Javadoc site meaningful package overviews

## Test plan

- [ ] `mvn verify` passes with no SLF4J or Mockito warnings in test output
- [ ] `mvn spotless:check` passes (all package-info files formatted correctly)
- [ ] Mockito self-attach warning no longer appears in any module's test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)