### PR TITLE
Document filter-order and purge.enabled in README config

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ idempotency:
   default-ttl: PT24H              # Default TTL for stored responses. Default: 24h
   default-lock-timeout: PT10S     # Default lock timeout. Default: 10s
   max-body-bytes: 1048576         # Max request body size to fingerprint in bytes. Default: 1 MiB
+  filter-order: 0                 # Order of the idempotency filter in the filter chain. Default: 0
   purge:
+    enabled: true                 # Whether to register the purge scheduler. Default: true
     cron: "0 0 * * * *"          # Cron expression for purging expired records. Default: hourly
 ```
 


### PR DESCRIPTION
## Summary

- Add `idempotency.filter-order` to the configuration reference — controls the filter's position in the filter chain relative to other filters (e.g. security, logging). Default: `0`.
- Add `idempotency.purge.enabled` to the configuration reference — allows disabling the purge scheduler entirely. Default: `true`.

Both properties exist in `IdempotencyProperties` but were absent from the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)