### PR TITLE
drop jackson dependency from jdbc and redis stores

### DIFF
--- a/idempotency-core/src/main/java/io/github/josipmusa/idempotency/core/HeaderJson.java
+++ b/idempotency-core/src/main/java/io/github/josipmusa/idempotency/core/HeaderJson.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2026 Josip Musa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.josipmusa.idempotency.core;
+
+import io.github.josipmusa.idempotency.core.exception.IdempotencyCorruptRecordException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Encodes and decodes HTTP response headers as JSON, for {@link IdempotencyStore}
+ * implementations that persist a {@link StoredResponse} in a text or byte column.
+ *
+ * <p>The format is a JSON object mapping each header name to an array of its values,
+ * for example {@code {"Content-Type":["application/json"],"Set-Cookie":["a=1","b=2"]}},
+ * and {@code {}} for no headers. Stores are free to use another representation; this
+ * exists so they do not each need a JSON library for so small a job.
+ *
+ * <p>Decoding accepts any valid JSON of that shape. Anything else - a non-object, a
+ * header whose value is not an array of strings, a {@code null} header list, malformed
+ * escapes, or trailing content - is rejected as a corrupt record, since
+ * {@link StoredResponse} refuses null keys, values and elements on construction and
+ * therefore no such document could have been written by this library.
+ */
+public final class HeaderJson {
+
+    private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+
+    private HeaderJson() {}
+
+    /**
+     * Encodes headers as a JSON object of string keys to string arrays.
+     *
+     * @param headers the headers to encode, iterated in the map's own order
+     * @return the JSON representation, {@code {}} when there are no headers
+     */
+    public static String encode(Map<String, List<String>> headers) {
+        StringBuilder json = new StringBuilder(96).append('{');
+        boolean firstHeader = true;
+        for (Map.Entry<String, List<String>> header : headers.entrySet()) {
+            if (!firstHeader) {
+                json.append(',');
+            }
+            firstHeader = false;
+            encodeString(json, header.getKey());
+            json.append(':').append('[');
+            boolean firstValue = true;
+            for (String value : header.getValue()) {
+                if (!firstValue) {
+                    json.append(',');
+                }
+                firstValue = false;
+                encodeString(json, value);
+            }
+            json.append(']');
+        }
+        return json.append('}').toString();
+    }
+
+    /**
+     * Decodes headers previously written by {@link #encode(Map)}.
+     *
+     * @param json the JSON object to decode
+     * @return the headers, preserving the order they appear in the document
+     * @throws IdempotencyCorruptRecordException if {@code json} is not a JSON object
+     *                                           of string keys to string arrays
+     */
+    public static Map<String, List<String>> decode(String json) {
+        return new Decoder(json).decode();
+    }
+
+    private static void encodeString(StringBuilder json, String value) {
+        json.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"' -> json.append("\\\"");
+                case '\\' -> json.append("\\\\");
+                case '\b' -> json.append("\\b");
+                case '\t' -> json.append("\\t");
+                case '\n' -> json.append("\\n");
+                case '\f' -> json.append("\\f");
+                case '\r' -> json.append("\\r");
+                default -> {
+                    if (c < 0x20) {
+                        json.append("\\u00").append(HEX[(c >> 4) & 0xF]).append(HEX[c & 0xF]);
+                    } else {
+                        json.append(c);
+                    }
+                }
+            }
+        }
+        json.append('"');
+    }
+
+    /** A single-use recursive-descent reader for the header JSON shape. */
+    private static final class Decoder {
+
+        private final String json;
+        private int pos;
+
+        Decoder(String json) {
+            this.json = json;
+        }
+
+        Map<String, List<String>> decode() {
+            if (json == null) {
+                throw corrupt("headers JSON is null");
+            }
+            skipWhitespace();
+            Map<String, List<String>> headers = readObject();
+            skipWhitespace();
+            if (pos != json.length()) {
+                throw corrupt("unexpected trailing content");
+            }
+            return headers;
+        }
+
+        private Map<String, List<String>> readObject() {
+            expect('{');
+            Map<String, List<String>> headers = new LinkedHashMap<>();
+            skipWhitespace();
+            if (peek() == '}') {
+                pos++;
+                return headers;
+            }
+            while (true) {
+                skipWhitespace();
+                String name = readString();
+                skipWhitespace();
+                expect(':');
+                skipWhitespace();
+                headers.put(name, readStringArray());
+                skipWhitespace();
+                char next = peek();
+                pos++;
+                if (next == '}') {
+                    return headers;
+                }
+                if (next != ',') {
+                    throw corrupt("expected ',' or '}' at position " + (pos - 1));
+                }
+            }
+        }
+
+        private List<String> readStringArray() {
+            expect('[');
+            List<String> values = new ArrayList<>(2);
+            skipWhitespace();
+            if (peek() == ']') {
+                pos++;
+                return List.copyOf(values);
+            }
+            while (true) {
+                skipWhitespace();
+                values.add(readString());
+                skipWhitespace();
+                char next = peek();
+                pos++;
+                if (next == ']') {
+                    return List.copyOf(values);
+                }
+                if (next != ',') {
+                    throw corrupt("expected ',' or ']' at position " + (pos - 1));
+                }
+            }
+        }
+
+        private String readString() {
+            expect('"');
+            StringBuilder value = new StringBuilder(16);
+            while (true) {
+                char c = peek();
+                pos++;
+                if (c == '"') {
+                    return value.toString();
+                }
+                if (c != '\\') {
+                    value.append(c);
+                    continue;
+                }
+                char escape = peek();
+                pos++;
+                switch (escape) {
+                    case '"', '\\', '/' -> value.append(escape);
+                    case 'b' -> value.append('\b');
+                    case 't' -> value.append('\t');
+                    case 'n' -> value.append('\n');
+                    case 'f' -> value.append('\f');
+                    case 'r' -> value.append('\r');
+                    case 'u' -> value.append(readUnicodeEscape());
+                    default -> throw corrupt("unsupported escape '\\" + escape + "' at position " + (pos - 2));
+                }
+            }
+        }
+
+        /**
+         * Reads the four hex digits of a {@code \\uXXXX} escape. Each escape yields one
+         * UTF-16 code unit, so an escaped surrogate pair reassembles naturally.
+         */
+        private char readUnicodeEscape() {
+            if (pos + 4 > json.length()) {
+                throw corrupt("truncated unicode escape at position " + pos);
+            }
+            int codeUnit = 0;
+            for (int i = 0; i < 4; i++) {
+                int digit = Character.digit(json.charAt(pos + i), 16);
+                if (digit < 0) {
+                    throw corrupt("malformed unicode escape at position " + pos);
+                }
+                codeUnit = (codeUnit << 4) | digit;
+            }
+            pos += 4;
+            return (char) codeUnit;
+        }
+
+        private void skipWhitespace() {
+            while (pos < json.length()) {
+                char c = json.charAt(pos);
+                if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
+                    return;
+                }
+                pos++;
+            }
+        }
+
+        private void expect(char expected) {
+            char actual = peek();
+            if (actual != expected) {
+                throw corrupt("expected '" + expected + "' but found '" + actual + "' at position " + pos);
+            }
+            pos++;
+        }
+
+        private char peek() {
+            if (pos >= json.length()) {
+                throw corrupt("unexpected end of headers JSON");
+            }
+            return json.charAt(pos);
+        }
+
+        private IdempotencyCorruptRecordException corrupt(String detail) {
+            return new IdempotencyCorruptRecordException("Malformed response headers JSON: " + detail);
+        }
+    }
+}

--- a/idempotency-core/src/test/java/io/github/josipmusa/idempotency/core/HeaderJsonTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/idempotency/core/HeaderJsonTest.java
@@ -81,8 +81,7 @@ class HeaderJsonTest {
 
     @Test
     void When_ValueIsNonAscii_Expect_RawUtf8NotEscaped() {
-        assertThat(HeaderJson.encode(Map.of("X", List.of("héllo → 🎉"))))
-                .isEqualTo("{\"X\":[\"héllo → 🎉\"]}");
+        assertThat(HeaderJson.encode(Map.of("X", List.of("héllo → 🎉")))).isEqualTo("{\"X\":[\"héllo → 🎉\"]}");
     }
 
     @Test
@@ -119,7 +118,8 @@ class HeaderJsonTest {
 
     @Test
     void When_DuplicateKeys_Expect_LastWins() {
-        assertThat(HeaderJson.decode("{\"X\":[\"first\"],\"X\":[\"second\"]}")).isEqualTo(Map.of("X", List.of("second")));
+        assertThat(HeaderJson.decode("{\"X\":[\"first\"],\"X\":[\"second\"]}"))
+                .isEqualTo(Map.of("X", List.of("second")));
     }
 
     @Test

--- a/idempotency-core/src/test/java/io/github/josipmusa/idempotency/core/HeaderJsonTest.java
+++ b/idempotency-core/src/test/java/io/github/josipmusa/idempotency/core/HeaderJsonTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Josip Musa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.josipmusa.idempotency.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.josipmusa.idempotency.core.exception.IdempotencyCorruptRecordException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class HeaderJsonTest {
+
+    @Test
+    void When_SingleValuedHeader_Expect_JacksonCompatibleObject() {
+        assertThat(HeaderJson.encode(Map.of("Content-Type", List.of("application/json"))))
+                .isEqualTo("{\"Content-Type\":[\"application/json\"]}");
+    }
+
+    @Test
+    void When_EmptyMap_Expect_EmptyJsonObject() {
+        assertThat(HeaderJson.encode(Map.of())).isEqualTo("{}");
+    }
+
+    @Test
+    void When_MultiValuedHeader_Expect_AllValuesInOrder() {
+        assertThat(HeaderJson.encode(Map.of("Set-Cookie", List.of("a=1", "b=2"))))
+                .isEqualTo("{\"Set-Cookie\":[\"a=1\",\"b=2\"]}");
+    }
+
+    @Test
+    void When_HeaderWithNoValues_Expect_EmptyArray() {
+        assertThat(HeaderJson.encode(Map.of("X-Empty", List.of()))).isEqualTo("{\"X-Empty\":[]}");
+    }
+
+    @Test
+    void When_MultipleHeaders_Expect_EncodingOrderFollowsMapIteration() {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        headers.put("A", List.of("1"));
+        headers.put("B", List.of("2"));
+        assertThat(HeaderJson.encode(headers)).isEqualTo("{\"A\":[\"1\"],\"B\":[\"2\"]}");
+    }
+
+    @Test
+    void When_ValueContainsQuoteOrBackslash_Expect_Escaped() {
+        assertThat(HeaderJson.encode(Map.of("X", List.of("say \"hi\" c:\\tmp"))))
+                .isEqualTo("{\"X\":[\"say \\\"hi\\\" c:\\\\tmp\"]}");
+    }
+
+    @Test
+    void When_ValueContainsShorthandControlChars_Expect_ShorthandEscapes() {
+        assertThat(HeaderJson.encode(Map.of("X", List.of("a\bb\tc\nd\fe\rf"))))
+                .isEqualTo("{\"X\":[\"a\\bb\\tc\\nd\\fe\\rf\"]}");
+    }
+
+    @Test
+    void When_ValueContainsOtherControlChar_Expect_UnicodeEscape() {
+        assertThat(HeaderJson.encode(Map.of("X", List.of("a\u0001b\u001fc"))))
+                .isEqualTo("{\"X\":[\"a\\u0001b\\u001Fc\"]}");
+    }
+
+    @Test
+    void When_KeyNeedsEscaping_Expect_KeyEscapedToo() {
+        assertThat(HeaderJson.encode(Map.of("X-\"Odd\"", List.of("v")))).isEqualTo("{\"X-\\\"Odd\\\"\":[\"v\"]}");
+    }
+
+    @Test
+    void When_ValueIsNonAscii_Expect_RawUtf8NotEscaped() {
+        assertThat(HeaderJson.encode(Map.of("X", List.of("héllo → 🎉"))))
+                .isEqualTo("{\"X\":[\"héllo → 🎉\"]}");
+    }
+
+    @Test
+    void When_DecodingEncodedHeaders_Expect_RoundTrip() {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        headers.put("Content-Type", List.of("application/json"));
+        headers.put("Set-Cookie", List.of("a=1", "b=2"));
+        headers.put("X-Weird", List.of("\"quoted\"\t\\slash\\ héllo 🎉\u0001"));
+        headers.put("X-Empty", List.of());
+
+        assertThat(HeaderJson.decode(HeaderJson.encode(headers))).isEqualTo(headers);
+    }
+
+    @Test
+    void When_DecodingEmptyJsonObject_Expect_EmptyMap() {
+        assertThat(HeaderJson.decode("{}")).isEmpty();
+    }
+
+    @Test
+    void When_JsonHasInsignificantWhitespace_Expect_Ignored() {
+        assertThat(HeaderJson.decode("  { \"A\" : [ \"1\" , \"2\" ] , \"B\" : [ ] }  "))
+                .isEqualTo(Map.of("A", List.of("1", "2"), "B", List.of()));
+    }
+
+    @Test
+    void When_JsonUsesEscapesJacksonDoesNotEmit_Expect_Decoded() {
+        assertThat(HeaderJson.decode("{\"X\":[\"a\\/b\\u0041\\u00e9\"]}")).isEqualTo(Map.of("X", List.of("a/bAé")));
+    }
+
+    @Test
+    void When_JsonUsesSurrogatePairEscape_Expect_DecodedToSupplementaryChar() {
+        assertThat(HeaderJson.decode("{\"X\":[\"\\ud83c\\udf89\"]}")).isEqualTo(Map.of("X", List.of("🎉")));
+    }
+
+    @Test
+    void When_DuplicateKeys_Expect_LastWins() {
+        assertThat(HeaderJson.decode("{\"X\":[\"first\"],\"X\":[\"second\"]}")).isEqualTo(Map.of("X", List.of("second")));
+    }
+
+    @Test
+    void When_DecodedHeadersConstructStoredResponse_Expect_Accepted() {
+        Map<String, List<String>> decoded = HeaderJson.decode("{\"Content-Type\":[\"text/plain\"]}");
+        assertThat(new StoredResponse(200, decoded, new byte[0], java.time.Instant.EPOCH).headers())
+                .isEqualTo(Map.of("Content-Type", List.of("text/plain")));
+    }
+
+    @Test
+    void When_JsonIsNotAnObject_Expect_CorruptRecord() {
+        assertThatThrownBy(() -> HeaderJson.decode("[\"nope\"]")).isInstanceOf(IdempotencyCorruptRecordException.class);
+    }
+
+    @Test
+    void When_HeaderListIsNull_Expect_CorruptRecord() {
+        assertThatThrownBy(() -> HeaderJson.decode("{\"X\":null}"))
+                .isInstanceOf(IdempotencyCorruptRecordException.class);
+    }
+
+    @Test
+    void When_HeaderValueIsNotAString_Expect_CorruptRecord() {
+        assertThatThrownBy(() -> HeaderJson.decode("{\"X\":[1]}"))
+                .isInstanceOf(IdempotencyCorruptRecordException.class);
+    }
+
+    @Test
+    void When_HeaderValueIsNotAnArray_Expect_CorruptRecord() {
+        assertThatThrownBy(() -> HeaderJson.decode("{\"X\":\"v\"}"))
+                .isInstanceOf(IdempotencyCorruptRecordException.class);
+    }
+
+    @Test
+    void When_JsonIsTruncated_Expect_CorruptRecord() {
+        assertThatThrownBy(() -> HeaderJson.decode("{\"X\":[\"v\"]"))
+                .isInstanceOf(IdempotencyCorruptRecordException.class);
+    }
+
+    @Test
+    void When_JsonHasTrailingGarbage_Expect_CorruptRecord() {
+        assertThatThrownBy(() -> HeaderJson.decode("{\"X\":[\"v\"]}extra"))
+                .isInstanceOf(IdempotencyCorruptRecordException.class);
+    }
+
+    @Test
+    void When_JsonHasUnterminatedString_Expect_CorruptRecord() {
+        assertThatThrownBy(() -> HeaderJson.decode("{\"X\":[\"v]}"))
+                .isInstanceOf(IdempotencyCorruptRecordException.class);
+    }
+
+    @Test
+    void When_JsonHasInvalidUnicodeEscape_Expect_CorruptRecord() {
+        assertThatThrownBy(() -> HeaderJson.decode("{\"X\":[\"\\uZZZZ\"]}"))
+                .isInstanceOf(IdempotencyCorruptRecordException.class);
+    }
+
+    @Test
+    void When_JsonHasUnknownEscape_Expect_CorruptRecord() {
+        assertThatThrownBy(() -> HeaderJson.decode("{\"X\":[\"\\q\"]}"))
+                .isInstanceOf(IdempotencyCorruptRecordException.class);
+    }
+
+    @Test
+    void When_JsonIsBlank_Expect_CorruptRecord() {
+        assertThatThrownBy(() -> HeaderJson.decode("")).isInstanceOf(IdempotencyCorruptRecordException.class);
+    }
+}

--- a/providers/idempotency-jdbc/pom.xml
+++ b/providers/idempotency-jdbc/pom.xml
@@ -22,10 +22,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStore.java
+++ b/providers/idempotency-jdbc/src/main/java/io/github/josipmusa/idempotency/jdbc/JdbcIdempotencyStore.java
@@ -15,10 +15,8 @@
  */
 package io.github.josipmusa.idempotency.jdbc;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.josipmusa.idempotency.core.AcquireResult;
+import io.github.josipmusa.idempotency.core.HeaderJson;
 import io.github.josipmusa.idempotency.core.IdempotencyContext;
 import io.github.josipmusa.idempotency.core.IdempotencyStore;
 import io.github.josipmusa.idempotency.core.StoredResponse;
@@ -132,8 +130,6 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
 
     private final DataSource dataSource;
     private final long pollIntervalMs;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final TypeReference<Map<String, List<String>>> HEADERS_TYPE = new TypeReference<>() {};
 
     public JdbcIdempotencyStore(DataSource dataSource) {
         this(dataSource, true);
@@ -615,21 +611,13 @@ public class JdbcIdempotencyStore implements IdempotencyStore {
     // --- JSON serialization ---
 
     static String headersToJson(Map<String, List<String>> headers) {
-        try {
-            return OBJECT_MAPPER.writeValueAsString(headers);
-        } catch (JsonProcessingException e) {
-            throw new IdempotencyStoreException("Failed to serialize response headers to JSON", e);
-        }
+        return HeaderJson.encode(headers);
     }
 
     static Map<String, List<String>> jsonToHeaders(String json) {
         if (json == null || json.equals("{}")) {
             return Map.of();
         }
-        try {
-            return OBJECT_MAPPER.readValue(json, HEADERS_TYPE);
-        } catch (JsonProcessingException e) {
-            throw new IdempotencyCorruptRecordException("Failed to deserialize response headers from JSON", e);
-        }
+        return HeaderJson.decode(json);
     }
 }

--- a/providers/idempotency-redis/pom.xml
+++ b/providers/idempotency-redis/pom.xml
@@ -27,10 +27,6 @@
             <artifactId>lettuce-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/providers/idempotency-redis/src/main/java/io/github/josipmusa/idempotency/redis/RedisIdempotencyStore.java
+++ b/providers/idempotency-redis/src/main/java/io/github/josipmusa/idempotency/redis/RedisIdempotencyStore.java
@@ -15,9 +15,8 @@
  */
 package io.github.josipmusa.idempotency.redis;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.josipmusa.idempotency.core.AcquireResult;
+import io.github.josipmusa.idempotency.core.HeaderJson;
 import io.github.josipmusa.idempotency.core.IdempotencyContext;
 import io.github.josipmusa.idempotency.core.IdempotencyStore;
 import io.github.josipmusa.idempotency.core.StoredResponse;
@@ -38,7 +37,6 @@ import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import io.lettuce.core.codec.RedisCodec;
 import io.lettuce.core.codec.StringCodec;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -92,8 +90,6 @@ public class RedisIdempotencyStore implements IdempotencyStore {
     static final String FORMAT_VERSION = "1";
 
     private static final long MAX_POLL_INTERVAL_MS = 1_000;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final TypeReference<Map<String, List<String>>> HEADERS_TYPE = new TypeReference<>() {};
 
     /** KEYS: record. ARGV: lock timeout, TTL, grace, fingerprint, lease, owner, format. */
     private static final LuaScript ACQUIRE = LuaScript.of(
@@ -592,21 +588,13 @@ public class RedisIdempotencyStore implements IdempotencyStore {
     }
 
     static byte[] headersToJson(Map<String, List<String>> headers) {
-        try {
-            return OBJECT_MAPPER.writeValueAsBytes(headers);
-        } catch (IOException e) {
-            throw new IdempotencyStoreException("Failed to serialize response headers to JSON", e);
-        }
+        return HeaderJson.encode(headers).getBytes(StandardCharsets.UTF_8);
     }
 
     static Map<String, List<String>> jsonToHeaders(byte[] json) {
         if (json == null || json.length == 0) {
             return Map.of();
         }
-        try {
-            return OBJECT_MAPPER.readValue(json, HEADERS_TYPE);
-        } catch (IOException e) {
-            throw new IdempotencyCorruptRecordException("Stored Redis response headers are malformed", e);
-        }
+        return HeaderJson.decode(new String(json, StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
Both storage providers pulled in `jackson-databind` purely to turn the `Map<String, List<String>>` of response headers into a JSON string, which meant the library dictated a Jackson major version to every consumer. Issue #122 asked for a move to Jackson 3, but Spring Boot 4's BOM manages both `com.fasterxml.jackson` (2.21.5) and `tools.jackson` (3.1.5), so a Boot 4 upgrade would neither break the existing Jackson 2 usage nor migrate it - and picking either major would be a breaking change for consumers on the other, revisited again at Jackson 4. Removing the dependency settles it permanently and restores the intended `providers/*` boundary, where the Jackson version was previously inherited from Spring's BOM.

Closes #122