### PR TITLE
give the failed-record purge test a workable time budget

### DIFF
--- a/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
+++ b/idempotency-test/src/main/java/io/github/josipmusa/idempotency/test/IdempotencyStoreContract.java
@@ -783,11 +783,16 @@ public abstract class IdempotencyStoreContract {
         IdempotencyStore s = store();
         String key = "failed-expiry-contract";
 
-        // Acquire with a very short lock
-        acquire(s, contextFor(key, Duration.ofMillis(50)));
+        // release() dates the FAILED record at now + lockTimeout, so lockTimeout is also the
+        // budget this test has between release() and purgeExpired(). Keep it far above the
+        // round-trip cost of those two calls: a 50ms budget was roughly the cost of the calls
+        // themselves against a containerised database and made this test flaky on CI.
+        Duration lockTimeout = Duration.ofSeconds(2);
+
+        acquire(s, contextFor(key, lockTimeout));
 
         // Wait for the lock to expire, then release
-        Thread.sleep(100);
+        Thread.sleep(lockTimeout.toMillis() + 100);
         release(s, key);
 
         // Purge immediately — the FAILED record should NOT be eligible yet.


### PR DESCRIPTION
release() dates a FAILED record at now + lockTimeout, so the 50ms lock timeout also capped how long the test had to reach purgeExpired(); those two store calls alone cost ~40-60ms against a containerised database, which is why this failed intermittently on CI.
